### PR TITLE
Updated email validation regex

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,7 @@
 var Utils = {
   isValidEmail: function(email) {
     // regex copied from http://stackoverflow.com/a/46181
-    var regex = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+    var regex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return regex.test(email);
   },
   convertToRoute: function(str) {


### PR DESCRIPTION
Fixes #1740

**Changes proposed in this pull request:**
- updated email validation regex

---

@Pomax I would love to get some help from you to check if that regex looks sane... It thinks `11%@hi.com` is a valid email which seems odd to me

but 
```
curl --data "lang=pt-BR&newsletters=mozilla-learning-network&email=11%@hi.com" https://basket-dev.allizom.org/news/subscribe/
``` 
returns `{"status": "ok"}` so maybe `11%@hi.com` is really a valid email?

/cc @alicoding 