### PR TITLE
replaces references to teach.mozilla.org with learning.mozilla.org 

### DIFF
--- a/pages/community/CommunityPage.jsx
+++ b/pages/community/CommunityPage.jsx
@@ -57,7 +57,7 @@ var CommunityPage = React.createClass({
           </section>
           <div className="vertical-divider"></div>
           <section className="text-center">
-            <h2>Get the latest teaching activities, tips, and news in your inbox every month. Sign up for the MLN Community Newsletter.</h2>
+            <h2>Get the latest teaching activities, tips, and news in your inbox every month. Sign up for the Mozilla Learning Newsletter.</h2>
             <SignupForm idPrefix="signup-form-" sourceUrl={this.props.currentPath} />
           </section>
           <section>

--- a/pages/home/ThankYouModal.jsx
+++ b/pages/home/ThankYouModal.jsx
@@ -4,8 +4,8 @@ var Modal = require('../../components/modal.jsx');
 var ThankYouModal = React.createClass({
   render: function() {
   // we can't preset the message sharing on Facebook
-  var facebookShare = "https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent("https://teach.mozilla.org");
-  var twitterShare = "https://twitter.com/home?status=" + encodeURIComponent("I love to #TeachTheWeb! https://teach.mozilla.org");
+  var facebookShare = "https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent("https://learning.mozilla.org");
+  var twitterShare = "https://twitter.com/home?status=" + encodeURIComponent("I love to #TeachTheWeb! https://learning.mozilla.org");
     return (
       <Modal modalTitle="Thanks for your interest!" className="modal-signup" hideModal={this.props.hideModal}>
         <p>We appreciate your commitment to keeping the web open, accessible and ours.</p>


### PR DESCRIPTION
fixes #1871

**Changes proposed in this pull request:**
- replaces "MLN Community Newsletter" with "Mozilla Learning Newsletter" on /community page
- replaces "teach.mozilla.org" with "learning.mozilla.org" in Facebook and Twitter shares at the end of the newsletter sign-up flow