### PR TITLE
replaces Twitter link in site footer and in CTAs on two pages

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -20,24 +20,25 @@ if (IN_STATIC_SITE) {
   }
 }
 
-exports.IN_STATIC_SITE = IN_STATIC_SITE;
-exports.GENERATING_STATIC_SITE = GENERATING_STATIC_SITE;
-exports.ENABLE_PUSHSTATE = ENABLE_PUSHSTATE;
-exports.IN_TEST_SUITE = (typeof describe == 'function');
 exports.DEV_SERVER_PORT = DEV_SERVER_PORT;
-exports.TWITTER_HANDLE = '@MozTeach';
-exports.TWITTER_LINK = 'https://twitter.com/MozTeach';
-exports.TEACH_THE_WEB_EMAIL = 'teachtheweb@mozillafoundation.org';
-exports.XRAY_GOGGLES_LINK = 'https://goggles.mozilla.org/';
-exports.THIMBLE = 'https://thimble.mozilla.org/';
-exports.FLICKR_MAKER_PARTY = 'https://www.flickr.com/photos/mozilladrumbeat/sets/72157654235131834/';
-exports.MAKE_METADATA_URL = process.env.MAKE_METADATA_URL || 'https://{username}.mywebmaker.org/makes.json';
-exports.HIVE_LEARNING_NETWORKS_URL = 'https://hivelearningnetworks.org';
-exports.WEBMAKER = 'https://webmaker.org';
-exports.MOZFEST_SITE_LINK = 'https://mozillafestival.org';
-exports.GIGABIT_SITE_LINK = 'https://mozilla.org/gigabit';
-exports.ORIGIN = ORIGIN;
-exports.LIGHT_BEAM_URL = "https://addons.mozilla.org/firefox/downloads/latest/363974/addon-363974-latest.xpi";
-exports.ENCRYPT_CAMPAIGN_URL = "https://mzl.la/encrypt";
-exports.WORDPRESS_SITE_URL = process.env.WORDPRESS_SITE_URL || '';
 exports.ENABLE_BADGES = !!process.env.ENABLE_BADGES;
+exports.ENABLE_PUSHSTATE = ENABLE_PUSHSTATE;
+exports.ENCRYPT_CAMPAIGN_URL = "https://mzl.la/encrypt";
+exports.FLICKR_MAKER_PARTY = 'https://www.flickr.com/photos/mozilladrumbeat/sets/72157654235131834/';
+exports.GENERATING_STATIC_SITE = GENERATING_STATIC_SITE;
+exports.GIGABIT_SITE_LINK = 'https://mozilla.org/gigabit';
+exports.HIVE_LEARNING_NETWORKS_URL = 'https://hivelearningnetworks.org';
+exports.IN_STATIC_SITE = IN_STATIC_SITE;
+exports.IN_TEST_SUITE = (typeof describe == 'function');
+exports.LIGHT_BEAM_URL = "https://addons.mozilla.org/firefox/downloads/latest/363974/addon-363974-latest.xpi";
+exports.MAKE_METADATA_URL = process.env.MAKE_METADATA_URL || 'https://{username}.mywebmaker.org/makes.json';
+exports.MOZFEST_SITE_LINK = 'https://mozillafestival.org';
+exports.ORIGIN = ORIGIN;
+exports.TEACH_THE_WEB_EMAIL = 'teachtheweb@mozillafoundation.org';
+exports.THIMBLE = 'https://thimble.mozilla.org/';
+exports.TWITTER_HANDLE = '@MozLearn';
+exports.TWITTER_LINK = 'https://twitter.com/MozLearn';
+exports.WEBMAKER = 'https://webmaker.org';
+exports.WORDPRESS_SITE_URL = process.env.WORDPRESS_SITE_URL || '';
+exports.XRAY_GOGGLES_LINK = 'https://goggles.mozilla.org/';
+

--- a/pages/community/CommunityPage.jsx
+++ b/pages/community/CommunityPage.jsx
@@ -10,6 +10,8 @@ var VerticalCard = require('./VerticalCard.jsx');
 
 var validateSignupForm = require('../../components/newsletter-signup/validateSignupForm');
 
+var config = require('../../config/config.js');
+
 var communityList = [
   {
     imgSrc1x: '/img/pages/community/clubs.jpg',
@@ -66,12 +68,12 @@ var CommunityPage = React.createClass({
           <section>
           <IconLinks>
             <IconLink
-              link="https://twitter.com/mozlearn"
+              link={ config.TWITTER_LINK }
               imgSrc="/img/pages/community/svg/icon-community-twitter.svg"
               width={60}
               head="Follow Us"
-              subhead="We're @mozlearn on Twitter and our community uses #teachtheweb"
-              highlightedText="@mozlearn"
+              subhead={"We're " + config.TWITTER_HANDLE + " on Twitter and our community uses #teachtheweb" }
+              highlightedText={ config.TWITTER_HANDLE }
             />
             <IconLink
               link="https://docs.google.com/a/mozillafoundation.org/forms/d/1bOXV1OiF2EKS5KprlnzfFpwaoVNwxLAwN_UEq6hGKqU/viewform"

--- a/pages/community/CommunityPage.jsx
+++ b/pages/community/CommunityPage.jsx
@@ -66,12 +66,12 @@ var CommunityPage = React.createClass({
           <section>
           <IconLinks>
             <IconLink
-              link="https://twitter.com/mozteach"
+              link="https://twitter.com/mozlearn"
               imgSrc="/img/pages/community/svg/icon-community-twitter.svg"
               width={60}
               head="Follow Us"
-              subhead="We're @mozteach on Twitter and our community uses #teachtheweb"
-              highlightedText="@mozteach"
+              subhead="We're @mozlearn on Twitter and our community uses #teachtheweb"
+              highlightedText="@mozlearn"
             />
             <IconLink
               link="https://docs.google.com/a/mozillafoundation.org/forms/d/1bOXV1OiF2EKS5KprlnzfFpwaoVNwxLAwN_UEq6hGKqU/viewform"

--- a/pages/opportunities/OpportunitiesPage.jsx
+++ b/pages/opportunities/OpportunitiesPage.jsx
@@ -29,8 +29,8 @@ var OpportunitiesPage = React.createClass({
                 imgSrc="/img/pages/opportunities/svg/icon-leadership-twitter.svg"
                 width={60}
                 head="Follow Us"
-                subhead="We're @mozteach on Twitter and our community uses #teachtheweb"
-                highlightedText="@mozteach"
+                subhead="We're @mozlearn on Twitter and our community uses #teachtheweb"
+                highlightedText="@mozlearn"
               />
               <IconLink
                 link="https://discourse.webmaker.org/"


### PR DESCRIPTION
Fixes #1877

**Changes proposed in this pull request:**
- replace @MozTeach with @MozLearn in config file to match new Twitter handle
- organize exports in config.js by alpha
- replace @MozTeach with @MozLearn on two pages where it was specifically mentioned (/opportunities and /community)


