### PR TITLE
Renamed WORDPRESS_SITE_URL to WORDPRESS_DOMAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ software works.
 `OPTIMIZELY_ID` | Optimizely Project ID (not a secret) e.g. '206878104'
 `OPTIMIZELY_ACTIVE` | If set to 'yes' (String) the project will include Optimizely snippet in the page load
 `MAKE_METADATA_URL` | The template source url to load users' Makes metadata. Username should be included in the URL as a variable. e.g., `https://{username}.makes.org/makes.json`
-`WORDPRESS_SITE_URL` | The URL to the wordpress.com site this app retrieves data from. e.g., `helloworld.wordpress.com`,
+`WORDPRESS_DOMAIN` | The domain to the wordpress.com site this app retrieves data from. e.g., `helloworld.wordpress.com` (with no protocol),
 
 ### Using Environment Variables in Local Development
 

--- a/config/config.js
+++ b/config/config.js
@@ -39,6 +39,6 @@ exports.THIMBLE = 'https://thimble.mozilla.org/';
 exports.TWITTER_HANDLE = '@MozLearn';
 exports.TWITTER_LINK = 'https://twitter.com/MozLearn';
 exports.WEBMAKER = 'https://webmaker.org';
-exports.WORDPRESS_SITE_URL = process.env.WORDPRESS_SITE_URL || '';
+exports.WORDPRESS_DOMAIN = process.env.WORDPRESS_DOMAIN || '';
 exports.XRAY_GOGGLES_LINK = 'https://goggles.mozilla.org/';
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
       'OPTIMIZELY_ID',
       'OPTIMIZELY_ACTIVE',
       'MAKE_METADATA_URL',
-      'WORDPRESS_SITE_URL',
+      'WORDPRESS_DOMAIN',
       // feature flags:
       "ENABLE_BADGES"
     ])),

--- a/lib/wp-page-checker.js
+++ b/lib/wp-page-checker.js
@@ -1,8 +1,8 @@
 var request = require('superagent');
 var config = require('../config/config');
 
-var WORDPRESS_SITE_URL = config.WORDPRESS_SITE_URL;
-var WORDPRESS_COM_API_ENDPOINT_BASE = 'https://public-api.wordpress.com/rest/v1.1/sites/' + WORDPRESS_SITE_URL + '/posts/slug:';
+var WORDPRESS_DOMAIN = config.WORDPRESS_DOMAIN;
+var WORDPRESS_COM_API_ENDPOINT_BASE = 'https://public-api.wordpress.com/rest/v1.1/sites/' + WORDPRESS_DOMAIN + '/posts/slug:';
 
 module.exports = function(path, callback) {
   // FIXME: this is implemented based on the assumption that 

--- a/pages/wp-content.jsx
+++ b/pages/wp-content.jsx
@@ -8,7 +8,7 @@ var WpContent = function(props) {
   return (
     <div className="wp-content-wrapper">
       <div className="inner-container">
-        <WpContentLoader wpUrl={config.WORDPRESS_SITE_URL} wpPostSlug={props.params.wpSlug}>
+        <WpContentLoader wpUrl={config.WORDPRESS_DOMAIN} wpPostSlug={props.params.wpSlug}>
           <NotFoundMessage/>
         </WpContentLoader>
       </div>


### PR DESCRIPTION
Fixed #1860 

Before merging this PR

- make sure env var `WORDPRESS_SITE_URL` is renamed to `WORDPRESS_DOMAIN` on Heroku