### PR TITLE
CSP - allow all image sources 

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,11 +117,7 @@ app.use(helmet.contentSecurityPolicy({
     imgSrc: [
       '\'self\'',
       '\'unsafe-inline\'',
-      'twemoji.maxcdn.com',
-      'https://upload.wikimedia.org',
-      '*.tiles.mapbox.com',
-      'www.google-analytics.com',
-      '*.log.optimizely.com'
+      '*'
     ],
     connectSrc: [
       '\'self\'',


### PR DESCRIPTION

Fixes # MozillaFoundation/mofo-devops#365

**Changes proposed in this pull request:**
- Allow all origins in the img-src CSP directive


