### PR TITLE
New Clubs Guides & Resources page

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,6 +127,7 @@ if (!fs.existsSync(DIST_DIR)) {
       'https://www.google.com',
       '*.tiles.mapbox.com',
       '*.log.optimizely.com',
+      '*.github.io',
       '*.mywebmaker.org',
       '*.makes.org',
       'bitly.mofoprod.net',

--- a/components/sidebar/topLevelNavItems.jsx
+++ b/components/sidebar/topLevelNavItems.jsx
@@ -33,6 +33,10 @@ var MENU_ENTRIES = [
         to: '/clubs'
       },
       {
+        name: "Guides & Resources",
+        to: '/clubs/guides'
+      },
+      {
         name: "maker_party",
         to: '/events'
       },

--- a/less/components/sidebar.less
+++ b/less/components/sidebar.less
@@ -212,5 +212,11 @@ html.no-js .sidebar {
     display: inline-block;
     font-weight: 600;
     padding: 0;
+
+    &[href*='/clubs/guides'] {
+      position: relative;
+      left: 16px;
+    }
+
   }
 }

--- a/less/pages/clubs-guides.less
+++ b/less/pages/clubs-guides.less
@@ -1,0 +1,72 @@
+.clubs-guides {
+
+  .guideList {
+    margin: 30px 0 35px 0;
+  }
+
+  .resourceCategory {
+    border-bottom: solid 1px #d7d8d9;
+    margin: 30px 0;
+    padding: 0 0 25px 0;
+
+    &:last-child {
+      border: none;
+    }
+
+    h3 {
+      font-weight: 300;
+      margin: 0 0 15px 0;
+      padding: 0;
+    }
+
+    ul {
+      list-style-type: none;
+      padding: 0;
+
+      li {
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    .translations {
+      font-style: italic;
+      padding-left: 15px;
+      opacity: .7;
+      list-style-type: none;
+      padding-left: 25px;
+      margin: 3px 0;
+
+      .language {
+        opacity: .6;
+      }
+
+      li {
+        line-height: .85em;
+
+        &:before {
+          content: '\2022';
+          position: relative;
+          left: -6px;
+          font-style: normal;
+        }
+
+        a {
+          line-height: 1.4em;
+        }
+      }
+
+      a:after {
+        content: ","
+      }
+
+      a:last-of-type:after {
+        content: "";
+      }
+
+      *  {
+        font-size: 1em;
+      }
+    }
+  }
+}

--- a/less/pages/index.less
+++ b/less/pages/index.less
@@ -17,3 +17,4 @@
 @import "curriculum-workshop";
 @import "wp-content";
 @import "badges";
+@import "clubs-guides";

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -30,6 +30,7 @@ var pages = {
   'activities/back-to-school-write-the-web': require('../pages/back-to-school-write-the-web.jsx'),
   'clubs': require('../pages/clubs.jsx'),
   'clubs/list': require('../pages/clubs-list.jsx'),
+  'clubs/guides': require('../pages/clubs-guides/ClubsGuides.jsx'),
   // NOTE: 'codemoji' is reserved. See https://github.com/mozilla/teach.mozilla.org/issues/1798
   'community': require('../pages/community.jsx'),
   'community/curriculum-workshop': require('../pages/curriculum-workshop.jsx'),

--- a/pages/clubs-guides/ClubsGuides.jsx
+++ b/pages/clubs-guides/ClubsGuides.jsx
@@ -1,0 +1,92 @@
+var React = require('react');
+var HeroUnit = require('../../components/hero-unit.jsx');
+
+var GuideList = React.createClass({
+  getInitialState: function(){
+    return {
+      guides : []
+    }
+  },
+  setData : function(data){
+    this.setState({guides : data });
+  },
+  fetchJSON : function(path,callback){
+    var httpRequest = new XMLHttpRequest();
+    httpRequest.onreadystatechange = function() {
+      if(httpRequest.readyState === 4) {
+        if(httpRequest.status === 200) {
+          var data = JSON.parse(httpRequest.responseText);
+          if (typeof callback === "function") callback(data);
+        }
+      }
+    };
+    httpRequest.open('GET', path);
+    httpRequest.send();
+  },
+  componentDidMount: function() {
+    this.fetchJSON("https://mozilla.github.io/learning-networks/clubs/clubs-resources.json",this.setData);
+  },
+  getLinks : function(){
+    var categories = this.state.guides.map(function(category){
+      var guideLinks = category.guides.map(function(guide){
+
+        if(guide.translations && guide.translations.length > 0){
+          var translationLinks = guide.translations.map(function(translation){
+            return (
+              <li>
+                <a href={ translation.url }>{ translation.title }</a><span className="language"> - ({ translation.language })</span>
+              </li>
+            );
+          });
+        }
+
+        return (
+          <li>
+            <a href={guide.url}>{ guide.title }</a>
+            { translationLinks ? <ul className="translations">{ translationLinks }</ul> : "" }
+          </li>
+        );
+      });
+
+      return (
+        <section className="resourceCategory">
+          <h3> { category.category } </h3>
+          <ul>
+            { guideLinks }
+          </ul>
+        </section>
+      );
+    });
+    return categories;
+  },
+  render: function(){
+    return(
+      <div className="guideList">
+        { this.getLinks() }
+      </div>
+    )
+  }
+});
+
+var ClubsGuides = React.createClass({
+  statics: {
+    pageClassName: 'clubs-guides',
+    pageTitle: 'Clubs Guides & Resources'
+  },
+  render: function () {
+    return (
+      <div>
+        <HeroUnit>
+          <h1>Mozilla Clubs</h1>
+          <h2>Local groups teaching the Web around the world</h2>
+        </HeroUnit>
+        <div className="inner-container">
+          <h2>Clubs Guides &amp; Resources</h2>
+          <GuideList></GuideList>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ClubsGuides;

--- a/pages/clubs.jsx
+++ b/pages/clubs.jsx
@@ -175,7 +175,7 @@ var ApplyCallout = React.createClass({
           <div className="vertical-divider"></div>
           <h3 className="text-center">To get matched with a Regional Coordinator, please apply to be a Mozilla Club Captain.</h3>
           <a className="btn" onClick={this.props.showAddYourClubModal}>Apply to be a Club Captain</a>
-          <p className="check-out-resources">If you’d like to get started on your own, check out these <a href="http://mozilla.github.io/learning-networks/clubs/">resources</a>.</p>
+          <p className="check-out-resources">If you’d like to get started on your own, check out the <a href="http://mozilla.github.io/learning-networks/clubs/facts">Fact Sheet</a>.</p>
         </div>
       </section>
     );
@@ -277,7 +277,7 @@ var ClubsPage = React.createClass({
                 highlightedText="Connect"
               />
               <IconLink
-                link="http://mozilla.github.io/learning-networks/clubs/facts"
+                link="/clubs/guides"
                 imgSrc="/img/pages/clubs/svg/icon-tips.svg"
                 head="Get Help"
                 subhead="Resources for running your Club."


### PR DESCRIPTION
**Summary**
Added a new Clubs Guides page to the Learning site. The page is populated from a JSON file that lives in the learning networks repo. Full details below.

**Specific Changes**
* Added Clubs Guides & Resources page
* Links on the page are generated from [this JSON file ](https://mozilla.github.io/learning-networks/clubs/clubs-resources.json)
* When available, the page also lists translated versions of a resource
  * This page can be edited, and the changes will be reflected on the Learning site
* Added a nav item to the left-hand side nav
* Changed a permissions rule to allow the Learning site to pull in data from ``*.github.io`` domains
* Linked the new page from the existing Clubs page

Fixes #1966 