### PR TITLE
Fix build error for postinstall - related to l10n

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "presmoketest": "npm run cleanup",
     "prestart": "rm -rf dist",
     "pretest": "npm run cleanup",
-    "postinstall": "gulp postinstall",
+    "postinstall": "gulp postinstall && npm run l10n",
     "smoketest": "gulp smoketest",
     "start": "npm run app",
     "test": "gulp smoketest && npm run test:mocha && npm run test:browser && gulp lint-test",


### PR DESCRIPTION
I broke the build after introducing l10n here, but this is what causes the issue. 

```
Error: ./lib/page-generate.jsx
       Module not found: Error: Cannot resolve 'file' or 'directory' ../dist/locales.json in /tmp/build_d6aca50ad29e8ab3a65c281def8a57f2/mozilla-learning.mozilla.org-229092d/lib
```