### PR TITLE
Fix Safari bug, change 301 to 307 redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -278,7 +278,7 @@ app.use(function(req, res, next) {
   var parsedRedirect = parsed.redirect;
   // See if we should redirect.
   if (parsedRedirect) {
-    res.redirect(301, "/" + parsedLocale + parsedRedirect + search);
+    res.redirect(307, "/" + parsedLocale + parsedRedirect + search);
   } else {
     next();
   }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "minimatch": "^3.0.0",
     "minimist": "^1.2.0",
     "mocha": "^2.1.0",
-    "mofo-localize": "0.0.3",
+    "mofo-localize": "0.0.4",
     "mofo-style": "^1.0.1",
     "moment": "^2.10.3",
     "mozilla-tabzilla": "^0.5.1",


### PR DESCRIPTION
Fixes #2005

**Changes proposed in this pull request:**
- Change 301 permanent redirect to 307 temporary (solves debugging issues, really shouldn't be permanent because a user may want to change locale)
- Bump mofo-localizr so that lowercase regions in "accept-language" header don't fail