### PR TITLE
Removing X-Frame-Options

### DIFF
--- a/app.js
+++ b/app.js
@@ -153,10 +153,6 @@ app.use(helmet.xssFilter({
   setOnOldIE: true
 }));
 
-app.use(helmet.frameguard({
-  action: 'deny'
-}));
-
 app.use(helmet.hsts({
   maxAge: 1000 * 60 * 60 * 24 * 90
 }));


### PR DESCRIPTION
Since we already added `frame-ancestor` in CSP, we don't need this no more!