### PR TITLE
Fix l10n warning when running tests

### DIFF
--- a/test/browser/page.test.jsx
+++ b/test/browser/page.test.jsx
@@ -3,6 +3,7 @@ var sinon = window.sinon;
 var React =require('react');
 var ReactDOM = require('react-dom');
 var IntlProvider = require('react-intl').IntlProvider;
+var locales = require('../../dist/locales.json');
 
 var ReactRouter = require('react-router');
 var Router = ReactRouter.Router;
@@ -25,7 +26,7 @@ describe("page", function() {
 
   function visitPage(url, cb) {
     match({routes: generator.routes, location: url}, function(error, redirect, props) {
-      handler = TestUtils.renderIntoDocument(<IntlProvider><RoutingContext {...props}/></IntlProvider>);
+      handler = TestUtils.renderIntoDocument(<IntlProvider locale="en-US" messages={locales['en-US']}><RoutingContext {...props}/></IntlProvider>);
       page = TestUtils.findAllInRenderedTree(handler, function(c) {
         return !!c.showModal;
       })[0];


### PR DESCRIPTION
Currently when run `npm test` there are bunch of warning something like:

```
[React Intl] Cannot format message: "learn_more", using message id as fallback.
[React Intl] Missing message: "follow_us" for locale: "en"
```

This is because we haven't pass the messages object to the `IntlProvider` for test runner.