### PR TITLE
fixes the prop2json script by making a path lookup cross-platform

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -7,6 +7,14 @@ var Redirect = ReactRouter.Redirect;
 var IndexRoute  = ReactRouter.IndexRoute;
 var locales = Object.keys(require('../dist/locales.json'));
 
+
+// verify we have at least one locale
+if (Object.keys(locales).length === 0) {
+  console.error("No locales were loaded into routes.jsx, no routes can be built!");
+  process.exit(1);
+}
+
+
 /**
  * Our base routes
  */

--- a/scripts/properties2json.js
+++ b/scripts/properties2json.js
@@ -14,14 +14,14 @@ function getListLocales() {
   return new Promise(function(resolve, reject) {
     if (supportedLocales === "*") {
       FS.listDirectoryTree(path.join(process.cwd(), config.src)).then(function(dirTree) {
-        var list = [];
-        dirTree.forEach(function(i) {
-          var that = i.split(config.src + '/');
-          if (that[1]) {
-            list.push(that[1]);
+        var localeList = [];
+        dirTree.forEach(function(localeLocation) {
+          var langcode = localeLocation.split(config.src + path.sep);
+          if (langcode[1]) {
+            localeList.push(langcode[1]);
           }
         });
-        return resolve(list);
+        return resolve(localeList);
       }).catch(function(e) {
         console.log(e);
         reject(e);


### PR DESCRIPTION
fixes https://github.com/mozilla/learning.mozilla.org/issues/2025 by replacing a `'/'` in a path, which only works on Unixy systems, with `path.sep`, which works on all operating systems.