### PR TITLE
Add the CSRF and withCredentials code back into the teach-api

### DIFF
--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -111,6 +111,17 @@ _.extend(TeachAPI.prototype, {
                      url + '. Not sending auth token.');
       }
     }
+ 
+    // do we need credentials + Django CSRF token?
+    if (['post','put','delete'].indexOf(method) > -1) {
+      var csrf = document.cookie.match(/csrftoken=\S+/);
+      if (csrf) {
+        csrf = csrf[0].replace(';','').split('=');
+        var token = csrf[1];
+        req.set('X-CSRFtoken', token ? token : "FALSE");
+        req.withCredentials();
+      }
+    }    
 
     return req;
   },


### PR DESCRIPTION
For unclear reasons the `teach-api.js` request function had lost the code that determines whether or not to supply the teach-api with credentials and the required Django CSRF token.

This PR restores that.