### PR TITLE
adds 'should a nav link be a hard reload' functionality

### DIFF
--- a/components/link-anchor-swap.jsx
+++ b/components/link-anchor-swap.jsx
@@ -4,25 +4,53 @@ var ga = require('react-ga');
 var classNames = require('classnames');
 var OutboundLink = ga.OutboundLink;
 
+var resetreload = require('../lib/resetreload');
+
 var LinkAnchorSwap = React.createClass({
   contextTypes: {
     intl: React.PropTypes.object
   },
+
   render: function() {
-    var link = this.props.to;
-    var ifExternalLink = (link.substr(0,4).toLowerCase() === "http") || (link.substr(0,7).toLowerCase() === "mailto:");
-    var classes = classNames(
-      this.props.className,
-      {
-        "external-link": ifExternalLink
-      }
-    );
     var linkedContent = this.props.children || this.props.name;
-    return (
-      ifExternalLink ?  <OutboundLink eventLabel={link} {...this.props}>{linkedContent}</OutboundLink> :
-                        <Link {...this.props} to={"/" + this.context.intl.locale + this.props.to } onClick={this.scrollToTop}>{linkedContent}</Link>
-    );
+    if (this.isExternalLink()) {
+      return <OutboundLink {...this.props} eventLabel={this.props.to}>{linkedContent}</OutboundLink>
+    }
+    return <Link {...this.props} to={this.getLocalizedTo()} onClick={this.handleClick}>{linkedContent}</Link>
   },
+
+  isExternalLink: function() {
+    var link = this.props.to;    
+    var weblink = (link.substr(0,4).toLowerCase() === "http");
+    var maillink = (link.substr(0,7).toLowerCase() === "mailto:");
+    return weblink || maillink;
+  },
+
+  getLocalizedTo: function() {
+    return "/" + this.context.intl.locale + this.props.to;
+  },
+
+  // preprocess a <link> click
+  handleClick: function(e) {
+    this.checkForReset(e)
+    this.scrollToTop();
+  },
+
+  /**
+   * We use <Link> for internal links in the app, but <Link> won't reload a page if
+   * that's the page we're already on, so we FORCE it to reset the <Page> instead.
+   */
+  checkForReset: function(e) {
+    if (typeof window !== "undefined" ) {
+      var curloc = (window.location.pathname === this.getLocalizedTo());
+      if (curloc && resetreload.shouldResetOnReload()) {
+        e.preventDefault();
+        resetreload.reset();
+      }
+    }
+  },
+
+  // scroll to the top of a page when navigating
   scrollToTop: function() {
     if (typeof window !== "undefined" && window.scrollTo) {
       window.scrollTo(0,0);

--- a/components/page.jsx
+++ b/components/page.jsx
@@ -5,6 +5,8 @@ var Router = require('react-router');
 var RouteHandler = Router.RouteHandler;
 var ga = require('react-ga');
 
+var resetreload = require('../lib/resetreload');
+
 var Sidebar = require('./sidebar.jsx');
 var Footer = require('./footer.jsx');
 var DevRibbon = (process.env.NODE_ENV === 'production' && process.env.SHOW_DEV_RIBBON !== 'on') ? null : require('./dev-ribbon.jsx');
@@ -67,9 +69,18 @@ var Page = React.createClass({
   // Lifecycle functions
 
   getInitialState: function() {
+    resetreload.bindPage(this);
     return {
       modalClass: null,
       modalProps: null
+    }
+  },
+
+  reset: function() {
+    var child = this.refs.pageContent;
+    var comp = child.getComponent();
+    if (comp && comp.reset) {
+      comp.reset();
     }
   },
 
@@ -145,7 +156,8 @@ var Page = React.createClass({
               React.cloneElement(this.props.children, {
                 showModal: this.showModal,
                 hideModal: this.hideModal,
-                currentPath: currentPath
+                currentPath: currentPath,
+                ref: "pageContent"
               })
             }
             </main>

--- a/lib/resetreload.js
+++ b/lib/resetreload.js
@@ -1,0 +1,29 @@
+/**
+ * Singleton library for determining whether to hard-reload a
+ * page, as <Link> does not allow hard reloads of the current page.
+ *
+ * This library works because node (and bundles) cache requirements.
+ */
+
+var curPage = false,
+    _reset = false;
+
+module.exports = {
+  bindPage: function(page) {
+    curPage = page;
+  },
+
+  shouldResetOnReload: function(reset) {
+    if (reset === false || reset === true) {
+      _reset = reset;
+    }
+    return _reset;
+  },
+
+  reset: function() {
+    _reset = false
+    if (curPage) {
+      curPage.reset();
+    }
+  }
+};

--- a/pages/clubs/ClubsPage.jsx
+++ b/pages/clubs/ClubsPage.jsx
@@ -6,6 +6,7 @@ var Link = require('react-router').Link;
 var withTeachAPI = require('../../hoc/with-teach-api.jsx');
 
 var fixLocation = require('../../lib/fix-location.js');
+var resetreload = require('../../lib/resetreload');
 
 var HeroUnit = require('../../components/hero-unit.jsx');
 var Map = require('../../components/map.jsx');
@@ -201,6 +202,9 @@ var ClubsPage = React.createClass({
       showApplication: false
     };
   },
+  reset: function() {
+    this.setState( this.getInitialState() );
+  },
   componentWillMount: function() {
     fixLocation(this.context.location);
   },
@@ -304,6 +308,7 @@ var ClubsPage = React.createClass({
   },
 
   showApplication: function() {
+    resetreload.shouldResetOnReload(true);
     this.setState({
       showApplication: true
     });


### PR DESCRIPTION
Since this is a single page app and navigation is for a single user in a single client, this PR introduces a library that tracks whether "nav actions for the same page" should hard reload or not, tied to the `LinkAnchorSwap` component.

If some component anywhere sets "hardreload" to true, then a linkanchorswap component for the page we are currently on will, rather than "do nothing", trigger a `window.location.reload()`

fixes https://github.com/mozilla/learning.mozilla.org/issues/2054