### PR TITLE
Fall back to en-US properly on incomplete locales

### DIFF
--- a/lib/page-generate.jsx
+++ b/lib/page-generate.jsx
@@ -23,6 +23,8 @@ var IntlProvider = ReactIntl.IntlProvider;
 var addLocaleData = ReactIntl.addLocaleData;
 var currentLocale;
 
+var assign = require('object-assign');
+
 /**
  * content for redirect pages
  */
@@ -48,7 +50,7 @@ function generateStaticRedirect(fromURL, toURL, next) {
 
 function createElement(Component, props) {
   var locale = this.locale;
-  var messages = locales[locale];
+  var messages =  assign({}, locales["en-US"], locales[locale]);
   // make sure you pass all the props in!
   return (
     <IntlProvider locale={locale} messages={messages}>
@@ -98,7 +100,7 @@ function run(location, el) {
 
   // Get locale from URL, use it to pass messages in to IntlProvider, but not before adding appropriate locale data (see index-static.jsx for how that gets in here)
   currentLocale = window.location.pathname.split('/')[1];
-  messages = locales[currentLocale];
+  messages = assign({}, locales["en-US"], locales[currentLocale]);
   // Keys are languages, not locales, so we just need the first part
   addLocaleData(window.ReactIntlLocaleData[currentLocale.split('-')[0]]);
 


### PR DESCRIPTION
Fixes #2080

**Changes proposed in this pull request:**
- When passing in messages for a locales, this first generates a new object with en-US keys, then overwrites it with supported strings from the current locale.


Could be optimized/refactored into mofo-localize, but this is a quick and easy win for now.
