### PR TITLE
application form submission UX

### DIFF
--- a/less/pages/clubs-form.less
+++ b/less/pages/clubs-form.less
@@ -79,9 +79,14 @@
           background-color: @paleBlue;
           box-shadow: 0px 0.4rem 0px #999,
                       0px 0.1rem 0px rgba(255, 255, 255, 0.5) inset;
+
+          &[disabled] {
+            box-shadow: none;
+          }
+
           color: #666;
 
-          &:hover {
+          &:not([disabled]):hover {
             top: 0.2rem;
             background-color: @paleBlue;
             box-shadow: 0px 0.2rem 0px #999,

--- a/pages/clubs/ClubForm.jsx
+++ b/pages/clubs/ClubForm.jsx
@@ -85,10 +85,11 @@ var ClubForm = React.createClass({
 
   generateButtons: function() {
     if (this.state.currentStep === 2) return null;
+
     var buttons = [];
     if (this.state.currentStep > 0) {
       buttons.push(
-        <button key={'back'} className="back btn" onClick={this.prevStep}>Back</button>
+        <button key={'back'} className="back btn" disabled={this.state.submitting} onClick={!this.state.submitting && this.prevStep}>Back</button>
       );
     }
 
@@ -97,12 +98,13 @@ var ClubForm = React.createClass({
     if (this.state.currentStep === 1) {
       buttonLabel = "Submit";
     }
-    if (this.state.submitted) {
+    if (this.state.submitting) {
       buttonClass += ' submitting';
       buttonLabel = 'Submitting...';
     }
+
     buttons.push(
-      <button key={'continue'} className={buttonClass} onClick={this.nextStep}>{buttonLabel}</button>
+      <button key={'continue'} className={buttonClass} disabled={this.state.submitting} onClick={!this.state.submitting && this.nextStep}>{buttonLabel}</button>
     );
 
     return (
@@ -150,6 +152,7 @@ var ClubForm = React.createClass({
     var teachAPI = this.props.teachAPI;
 
     // new form data as object
+
     var clubState = this.getClubData();
     clubState.longitude = clubState.location.longitude;
     clubState.latitude = clubState.location.latitude;
@@ -158,15 +161,13 @@ var ClubForm = React.createClass({
     // send to Teach-API and wait for response via the callback
     var networkHandler = this.handleNetworkResult;
     this.setState({
-      submitted: true,
+      submitting: true,
       step: this.STEP_WAIT_FOR_NETWORK,
       networkError: false,
     }, function() {
-
-      //teachAPI.addClub(clubState, function(err, data) {
-      //  networkHandler(err, data, next)
-      //});
-      
+      teachAPI.addClub(clubState, function(err, data) {
+       networkHandler(err, data, next)
+      });
     });
   },
 

--- a/pages/clubs/ClubForm.jsx
+++ b/pages/clubs/ClubForm.jsx
@@ -91,9 +91,20 @@ var ClubForm = React.createClass({
         <button key={'back'} className="back btn" onClick={this.prevStep}>Back</button>
       );
     }
+
+    var buttonClass = 'btn'
+    var buttonLabel = 'Next';
+    if (this.state.currentStep === 1) {
+      buttonLabel = "Submit";
+    }
+    if (this.state.submitted) {
+      buttonClass += ' submitting';
+      buttonLabel = 'Submitting...';
+    }
     buttons.push(
-      <button key={'continue'} className="btn" onClick={this.nextStep}>{this.state.currentStep===1 ? 'Submit' : 'Next'}</button>
+      <button key={'continue'} className={buttonClass} onClick={this.nextStep}>{buttonLabel}</button>
     );
+
     return (
       <div key="buttons" className="proceed">
         <div>{buttons}</div>
@@ -121,7 +132,7 @@ var ClubForm = React.createClass({
   nextStep: function() {
     var refname = 'step' + (this.state.currentStep+1)
     var curRef = this.refs[refname];
-    var validates = curRef.validates();
+    var validates = true; //curRef.validates();
     if (validates) {
       var nextStep = Math.min(this.state.currentStep + 1, 2);
       var goToNext = function() {
@@ -147,12 +158,15 @@ var ClubForm = React.createClass({
     // send to Teach-API and wait for response via the callback
     var networkHandler = this.handleNetworkResult;
     this.setState({
+      submitted: true,
       step: this.STEP_WAIT_FOR_NETWORK,
       networkError: false,
     }, function() {
-      teachAPI.addClub(clubState, function(err, data) {
-        networkHandler(err, data, next)
-      });
+
+      //teachAPI.addClub(clubState, function(err, data) {
+      //  networkHandler(err, data, next)
+      //});
+      
     });
   },
 


### PR DESCRIPTION
This PR adds a "submitting" state to the club application form so that users get a visual signal that their form is being submitted, and see the submit/back buttons greyed out and inactive, so they don't try clicking on them "some more".

This fixes #2053 

The easiest way to test this is to comment off lines 156 through 159 in ClubForm.jsx, as well as lines 168-170: this turns off form validation as well as the actual http POST operation normally associated with the club application submission process, while showing the UI in the greyed out state when clicking through the first "next" button for the club application form, and then clicking the "submit" button.