### PR TITLE
Move babel build dependencies from 'devDependencies' to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
     "watch": "gulp watch"
   },
   "dependencies": {
+    "babel-cli": "^6.11.4",
     "babel-core": "^6.3.21",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-react": "^6.11.1",
     "bootstrap": "^3.3.4",
     "chalk": "^1.1.1",
     "classnames": "^2.2.1",
@@ -108,11 +112,6 @@
     "webpack-stream": "^3.1.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-core": "^6.13.2",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-react": "^6.11.1",
     "marked": "^0.3.3",
     "mocha-phantomjs": "^4.0.1",
     "open": "0.0.5",


### PR DESCRIPTION
<!---
[ If your PR is ready for review ]
please apply the "PR needs review" label to it

[ otherwise ]
please put "WIP" in the PR title and apply the "PR needs work" label. Once PR is ready for review, remember to remove "WIP" from the PR title and replace "PR needs work" label with "PR needs review"
-->

<!-- You shouldn't have any user-facing English strings in jsx files. See https://github.com/mozilla/learning.mozilla.org/blob/master/L10N.md -->
- [X] Localization addressed

Fixes #2098 

**Changes proposed in this pull request:**
- Move babel build dependencies from 'devDependencies' to 'dependencies'


