### PR TITLE
code landed that should not have landed

### DIFF
--- a/pages/clubs/ClubForm.jsx
+++ b/pages/clubs/ClubForm.jsx
@@ -134,7 +134,7 @@ var ClubForm = React.createClass({
   nextStep: function() {
     var refname = 'step' + (this.state.currentStep+1)
     var curRef = this.refs[refname];
-    var validates = true; //curRef.validates();
+    var validates = curRef.validates();
     if (validates) {
       var nextStep = Math.min(this.state.currentStep + 1, 2);
       var goToNext = function() {


### PR DESCRIPTION
the clubform validation code contained a debug `=true; // real code here` line, which should not have been merged in but for whatever reason, had made it in.