### PR TITLE
fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "moment": "^2.10.3",
     "mozilla-tabzilla": "^0.5.1",
     "object-assign": "^4.1.0",
-    "pontoon-to-json": "^1.0.0",
+    "pontoon-to-json": "^1.0.1",
     "react": "^0.14.0",
     "react-addons-linked-state-mixin": "^0.14.3",
     "react-addons-pure-render-mixin": "^0.14.3",

--- a/test/index-static-singleton.js
+++ b/test/index-static-singleton.js
@@ -1,6 +1,8 @@
 var indexStaticWatcher = require('../lib/build/index-static-watcher').create();
 
 var indexStatic;
+var indexRebuildTimeout = 60000;
+
 
 exports.get = function() {
   if (!indexStatic) {
@@ -10,10 +12,12 @@ exports.get = function() {
 };
 
 exports.build = function(done) {
-  this.timeout(60000);
+  this.timeout(indexRebuildTimeout);
   indexStaticWatcher.build(function(err, newIndexStatic) {
     if (err) return done(err);
     indexStatic = newIndexStatic;
     done();
   });
 };
+
+exports.indexRebuildTimeout = indexRebuildTimeout;


### PR DESCRIPTION
- Bumps pontoon-to-json to 1.0.1 which has a fix for habitat not interpreting true environment variables (as opposed to vars read from file), and
- a fix that gives the indexStaticWatcher a timeout to be used by any test that relies on it (plus fixes to app.test.js, which relies on it).
- Also restricts the routes tested in app.test.js to only the `en-US` routes, to prevent a linear slowdown in testing whenever a new locale is added to our list of supported locales.