### PR TITLE
[DO NOT MERGE] test PR for running a rebuild as part of the procfile instruction

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: npm run start:prod

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -63,6 +63,7 @@ module.exports = {
       "LOGIN_EMULATION_LOGGEDOUT",
       "LOGIN_EMULATION_USERNAME"
     ])),
+    
     new webpack.optimize.CommonsChunkPlugin('commons',
                                             'commons.bundle.js')
   ].concat(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,13 @@ require('./gulp/copy.tasks.js')(gulp);
 require('./gulp/less.tasks.js')(gulp);
 require('./gulp/lint.tasks.js')(gulp);
 require('./gulp/webpack.tasks.js')(gulp);
-require('./gulp/test.tasks.js')(gulp);
-require('./gulp/watch.tasks.js')(gulp);
+
+// additional tasks outside of deployment
+if (process.argv.indexOf('--deploy') === -1) {
+	require('./gulp/test.tasks.js')(gulp);
+	require('./gulp/watch.tasks.js')(gulp);
+}
+
 require('./gulp/app.tasks.js')(gulp);
 
 // start the actual gulp run

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,8 @@ require('./gulp/webpack.tasks.js')(gulp);
 
 // additional tasks outside of deployment
 if (process.argv.indexOf('--deploy') === -1) {
-	require('./gulp/test.tasks.js')(gulp);
-	require('./gulp/watch.tasks.js')(gulp);
+  require('./gulp/test.tasks.js')(gulp);
+  require('./gulp/watch.tasks.js')(gulp);
 }
 
 require('./gulp/app.tasks.js')(gulp);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "test": "gulp smoketest && npm run test:mocha && npm run test:browser && gulp lint-test",
     "test:browser": "node test/browser/run-in-phantom.js",
     "test:mocha": "mocha test/*.test.js",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+
+    "start:prod": "npm run build -- --deploy && node app.js"
   },
   "dependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
adds a `start:prod` tasks that allows the project to rebuild and then run app.js, even when a slug is copied over using the "promote to production" heroku pipeline button.