### PR TITLE
Form field names

### DIFF
--- a/pages/clubs-list/ClubListItem.jsx
+++ b/pages/clubs-list/ClubListItem.jsx
@@ -36,7 +36,7 @@ var ClubListItem = React.createClass({
         <h4>{clubName} <Map.ClubStatusLabel showApproved={isOwned} status={club.status}/></h4>
         <p><span className="club-location" onClick={this.handleLocationClick}><span className="glyphicon glyphicon-map-marker"/> {club.location.split(',')[0]}</span></p>
         <p>{club.description}</p>
-        <p><small>Led by {club.owner}</small></p>
+        <p><small>Led by {club.full_name || club.owner}</small></p>
         {ownerControls}
       </li>
     );

--- a/pages/clubs/StepOne.jsx
+++ b/pages/clubs/StepOne.jsx
@@ -4,7 +4,7 @@ var LocationSelector = require('../../components/LocationSelector.jsx');
 var Select = require('react-select');
 
 var progressFields = [
-  "name",
+  "owner",
   "location",
   "occupation",
   "regionalCoordinator",
@@ -16,7 +16,7 @@ var StepOne = React.createClass({
   getInitialState: function() {
     this.optional = [];
     return {
-      name: null,
+      owner: null,
       location: null,
       occupation: null,
       regionalCoordinator: null,
@@ -60,7 +60,7 @@ var StepOne = React.createClass({
       <div className={className}>
         <fieldset>
           <label>Name</label>
-          <input className={this.error('name')} type="text" value={this.state.name} onChange={this.updateName} placeholder="Your full name"/>
+          <input className={this.error('owner')} type="text" value={this.state.owner} onChange={this.updateOwner} placeholder="Your full name"/>
         </fieldset>
 
         <fieldset>
@@ -111,7 +111,7 @@ var StepOne = React.createClass({
       </div>
     );
   },
-  updateName: function(evt) { this.setStateAsChange({ name: evt.target.value }); },
+  updateOwner: function(evt) { this.setStateAsChange({ owner: evt.target.value }); },
   updateLocation: function(locationdata) {
     try {
       locationdata = JSON.parse(locationdata);
@@ -129,7 +129,7 @@ var StepOne = React.createClass({
 
   getClubData: function() {
     var data = {
-      name: this.state.name,
+      owner: this.state.owner,
       location: this.state.location,
       occupation: this.state.occupation,
       'regional_coordinator': this.state.regionalCoordinator,
@@ -153,9 +153,9 @@ var StepOne = React.createClass({
     var errorElements = [];
     var errors = [];
 
-    if (!clubState.name) {
-      errorElements.push('name');
-      errors.push("You must provide a name for your club.");
+    if (!clubState.owner) {
+      errorElements.push('owner');
+      errors.push("You must provide your name.");
     }
     if (!clubState.location) {
       errorElements.push('location');

--- a/pages/clubs/StepOne.jsx
+++ b/pages/clubs/StepOne.jsx
@@ -4,7 +4,7 @@ var LocationSelector = require('../../components/LocationSelector.jsx');
 var Select = require('react-select');
 
 var progressFields = [
-  "fullname",
+  "fullName",
   "location",
   "occupation",
   "regionalCoordinator",
@@ -16,7 +16,7 @@ var StepOne = React.createClass({
   getInitialState: function() {
     this.optional = [];
     return {
-      fullname: null,
+      fullName: null,
       location: null,
       occupation: null,
       regionalCoordinator: null,
@@ -60,7 +60,7 @@ var StepOne = React.createClass({
       <div className={className}>
         <fieldset>
           <label>Name</label>
-          <input className={this.error('fullname')} type="text" value={this.state.fullname} onChange={this.updateFullName} placeholder="Your full name"/>
+          <input className={this.error('fullName')} type="text" value={this.state.fullName} onChange={this.updateFullName} placeholder="Your full name"/>
         </fieldset>
 
         <fieldset>
@@ -111,7 +111,7 @@ var StepOne = React.createClass({
       </div>
     );
   },
-  updateFullName: function(evt) { this.setStateAsChange({ fullname: evt.target.value }); },
+  updateFullName: function(evt) { this.setStateAsChange({ fullName: evt.target.value }); },
   updateLocation: function(locationdata) {
     try {
       locationdata = JSON.parse(locationdata);
@@ -129,7 +129,7 @@ var StepOne = React.createClass({
 
   getClubData: function() {
     var data = {
-      fullname: this.state.fullname,
+      'full_name': this.state.fullName,
       location: this.state.location,
       occupation: this.state.occupation,
       'regional_coordinator': this.state.regionalCoordinator,
@@ -153,8 +153,8 @@ var StepOne = React.createClass({
     var errorElements = [];
     var errors = [];
 
-    if (!clubState.fullname) {
-      errorElements.push('fullname');
+    if (!clubState.fullName) {
+      errorElements.push('fullName');
       errors.push("You must provide your name.");
     }
     if (!clubState.location) {

--- a/pages/clubs/StepOne.jsx
+++ b/pages/clubs/StepOne.jsx
@@ -4,7 +4,7 @@ var LocationSelector = require('../../components/LocationSelector.jsx');
 var Select = require('react-select');
 
 var progressFields = [
-  "owner",
+  "fullname",
   "location",
   "occupation",
   "regionalCoordinator",
@@ -16,7 +16,7 @@ var StepOne = React.createClass({
   getInitialState: function() {
     this.optional = [];
     return {
-      owner: null,
+      fullname: null,
       location: null,
       occupation: null,
       regionalCoordinator: null,
@@ -60,7 +60,7 @@ var StepOne = React.createClass({
       <div className={className}>
         <fieldset>
           <label>Name</label>
-          <input className={this.error('owner')} type="text" value={this.state.owner} onChange={this.updateOwner} placeholder="Your full name"/>
+          <input className={this.error('fullname')} type="text" value={this.state.fullname} onChange={this.updateFullName} placeholder="Your full name"/>
         </fieldset>
 
         <fieldset>
@@ -111,7 +111,7 @@ var StepOne = React.createClass({
       </div>
     );
   },
-  updateOwner: function(evt) { this.setStateAsChange({ owner: evt.target.value }); },
+  updateFullName: function(evt) { this.setStateAsChange({ fullname: evt.target.value }); },
   updateLocation: function(locationdata) {
     try {
       locationdata = JSON.parse(locationdata);
@@ -129,7 +129,7 @@ var StepOne = React.createClass({
 
   getClubData: function() {
     var data = {
-      owner: this.state.owner,
+      fullname: this.state.fullname,
       location: this.state.location,
       occupation: this.state.occupation,
       'regional_coordinator': this.state.regionalCoordinator,
@@ -153,8 +153,8 @@ var StepOne = React.createClass({
     var errorElements = [];
     var errors = [];
 
-    if (!clubState.owner) {
-      errorElements.push('owner');
+    if (!clubState.fullname) {
+      errorElements.push('fullname');
       errors.push("You must provide your name.");
     }
     if (!clubState.location) {

--- a/pages/clubs/StepTwo.jsx
+++ b/pages/clubs/StepTwo.jsx
@@ -2,7 +2,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 
 var startlabels = {
-  clubName: "Name your club",
+  name: "Name your club",
   description: "Description for your club",
   meetingVenue: "Where will you meet",
   frequency: "How often will you meet?",
@@ -13,7 +13,7 @@ var startlabels = {
 };
 
 var integrateLabels = {
-  clubName: "Name of your existing program",
+  name: "Name of your existing program",
   description: "Description for your existing program",
   meetingVenue: "Where do you meet",
   frequency: "How often do you meet?",
@@ -30,7 +30,7 @@ var labels = {
 
 var progressFields = [
   "intent",
-  "clubName",
+  "name",
   "description",
   "meetingVenue",
   "frequency",
@@ -46,7 +46,7 @@ var StepTwo = React.createClass({
     this.optional = ['affiliation'];
     return {
       intent: null,
-      clubName: null,
+      name: null,
       description: null,
       meetingVenue: null,
       frequency: null,
@@ -109,8 +109,8 @@ var StepTwo = React.createClass({
 
     return <div>
       <fieldset>
-        <label>{ labels[this.state.intent].clubName }</label>
-        <input className={this.error('clubName')} type="text" value={this.state.clubName} onChange={this.updateClubName} placeholder=""/>
+        <label>{ labels[this.state.intent].name }</label>
+        <input className={this.error('name')} type="text" value={this.state.name} onChange={this.updateClubName} placeholder=""/>
       </fieldset>
 
       <fieldset>
@@ -205,7 +205,7 @@ var StepTwo = React.createClass({
   },
 
   updateIntent: function(evt) { this.setStateAsChange({ intent: evt.target.value, errors: []}, true); },
-  updateClubName: function(evt) { this.setStateAsChange({ clubName: evt.target.value }); },
+  updateClubName: function(evt) { this.setStateAsChange({ name: evt.target.value }); },
   updateDescription: function(evt) { this.setStateAsChange({ description: evt.target.value }); },
   updateMeetingVenue: function(evt) { this.setStateAsChange({ meetingVenue: evt.target.value }); },
 
@@ -347,7 +347,7 @@ var StepTwo = React.createClass({
 
     var data = {
       intent: this.state.intent,
-      clubName: this.state.clubName,
+      name: this.state.name,
       description: this.state.description,
       venue: this.state.meetingVenue,
       frequency: freq,

--- a/pages/clubs/StepTwo.jsx
+++ b/pages/clubs/StepTwo.jsx
@@ -110,7 +110,7 @@ var StepTwo = React.createClass({
     return <div>
       <fieldset>
         <label>{ labels[this.state.intent].name }</label>
-        <input className={this.error('name')} type="text" value={this.state.name} onChange={this.updateClubName} placeholder=""/>
+        <input className={this.error('name')} type="text" value={this.state.name} onChange={this.updateName} placeholder=""/>
       </fieldset>
 
       <fieldset>
@@ -205,7 +205,7 @@ var StepTwo = React.createClass({
   },
 
   updateIntent: function(evt) { this.setStateAsChange({ intent: evt.target.value, errors: []}, true); },
-  updateClubName: function(evt) { this.setStateAsChange({ name: evt.target.value }); },
+  updateName: function(evt) { this.setStateAsChange({ name: evt.target.value }); },
   updateDescription: function(evt) { this.setStateAsChange({ description: evt.target.value }); },
   updateMeetingVenue: function(evt) { this.setStateAsChange({ meetingVenue: evt.target.value }); },
 
@@ -241,8 +241,8 @@ var StepTwo = React.createClass({
         errorElements.push('intent');
         errors.push("You need to fill in this part of the application.");
       } else {
-        if (!clubState.clubName) {
-          errorElements.push('clubName');
+        if (!clubState.name) {
+          errorElements.push('name');
           errors.push("You need to fill in the name of your club.");
         }
         if (!clubState.description) {


### PR DESCRIPTION
fixes #2100 

This aligns the club application form with the fields as used in the teach api:

- `owner` is the user's name
- `name` is the club name

The application was transmitting this information with the field names `name` and `clubName` respectively.

To test, fill in the application form and once submitted look at the clubs list, which should now show the club name rather than the owner name. (to see the wrong thing, try this in master and note that the user's name ends up as if it's club name)