### PR TITLE
webpack-loader for detecting undocumented environment variables

### DIFF
--- a/config/webpack/env-var-validator.js
+++ b/config/webpack/env-var-validator.js
@@ -1,0 +1,48 @@
+/**
+ * A webpack loader for looking at your bundle files
+ * and seeing whether any of the environment variables
+ * you rely on via process.env are actually documented
+ * in your README.md
+ */
+var fs = require('fs');
+var chalk = require('chalk');
+
+var basePattern = '([A-Z][A-Z_]*_[A-Z_]+)';
+var plainMatcher = new RegExp(basePattern, 'g');
+var processMatcher = new RegExp('process\\.env\\.' + basePattern, 'g');
+var habitatMatcher = new RegExp('env\\.get\\([\'"`]' + basePattern, 'g');
+
+// find all SNAKE_CASE variables, optionally using a specific regexp
+// for matching more than just the base SNAKE_CASE pattern
+function findSnakeCases(input, matcher) {
+  var terms = [];
+  matcher = matcher || plainMatcher;
+  input.replace(matcher, function(a, b) { terms.push(b); });
+  return terms;
+}
+
+var knownDocumented = {};
+var README = fs.readFileSync('./README.md').toString();
+findSnakeCases(README).forEach(function(varname) {
+  knownDocumented[varname] = true;
+});
+
+// check whether a given SNAKE_VAR variable has documentation
+function checkDocumentation(varname) {
+  if (!knownDocumented[varname]) {
+    console.warn('\n', chalk.yellow.bold('Found undocumented environment variable:'), chalk.red.bold(varname), '\n');
+  } 
+}
+
+/**
+ * A simple synchronouse webpack loader, checking for process.env as well
+ * as habitat-style env.get(...) patterns for environment variable mentions.
+ */
+module.exports = function findUndocumentedEnvironmentVariables(source) {
+  this.cacheable();
+  // check for process.env.SOME_VAR_NAME usage
+  findSnakeCases(source, processMatcher).forEach(checkDocumentation);
+  // check for env.get('SOME_VAR_NAME, quoted with either `, or ', or ".
+  findSnakeCases(source, habitatMatcher).forEach(checkDocumentation);
+  return source;
+};

--- a/config/webpack/webpack.client.config.js
+++ b/config/webpack/webpack.client.config.js
@@ -33,8 +33,19 @@ var webpackConfig = {
   },
   module: {
     loaders: [
-      { test: /\.jsx?$/, loaders:   ['babel', 'eslint'], exclude: /node_modules/ },
-      { test: /\.json$/, loader: 'json-loader' }
+      {
+        test: /\.jsx?$/,
+        loaders: [
+          'babel',
+          'eslint',
+          __dirname + '/../../config/webpack/env-var-validator.js'
+        ],
+        exclude: /node_modules/
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      }
     ]
   },
   plugins: [

--- a/config/webpack/webpack.server.config.js
+++ b/config/webpack/webpack.server.config.js
@@ -22,8 +22,18 @@ var webpackConfig = {
   },
   module: {
     loaders: [
-      { test: /\.jsx?$/, loaders: ['babel'], exclude: /node_modules/ },
-      { test: /\.json$/, loader: 'json-loader' }
+      {
+        test: /\.jsx?$/,
+        loaders: [
+          'babel',
+          __dirname + '/../../config/webpack/env-var-validator.js'
+        ],
+        exclude: /node_modules/
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      }
     ]
   },
   output: {

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "lint:fix": "eslint --ext .js --ext .jsx --fix .",
     "lint:server": "eslint --ext .js app.js ./server",
     "postinstall": "npm run prep",
-    "prep": "run-s cleanup copy-static-files less l10n webpack:static webpack",
+    "prep": "run-s cleanup copy-static-files less l10n webpack:server webpack:client",
     "start": "run-s webpack:* && run-p start:*",
+    "start:app": "node app",
     "start:less": "chokidar-cmd -c 'npm run less' -t less",
-    "start:app": "npm run webpack -- --watch",
-    "start:static": "npm run webpack:static -- --watch",
-    "start:server": "node app",
+    "start:client": "npm run webpack:client -- --watch",
+    "start:server": "npm run webpack:server -- --watch",
     "test": "run-s prep lint:server",
-    "webpack": "webpack --config ./config/webpack/webpack.client.config.js --progress --colors",
-    "webpack:static": "webpack --config ./config/webpack/webpack.server.config.js --progress --colors"
+    "webpack:client": "webpack --config ./config/webpack/webpack.client.config.js --progress --colors",
+    "webpack:server": "webpack --config ./config/webpack/webpack.server.config.js --progress --colors"
   },
   "babel": {
     "presets": [
@@ -52,7 +52,7 @@
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
     "bootstrap": "^3.3.4",
-    "chalk": "^1.1.1",
+    "chalk": "^1.1.3",
     "chokidar": "^1.6.0",
     "chokidar-cmd": "^1.2.1",
     "classnames": "^2.2.1",


### PR DESCRIPTION
This PR adds a webpack loader that runs as part of both the client and server webpack compiles to see if there is any mention of environment variables that are not documented in the README.md.

This is, by its very nature, a crude check and as such will not cause `npm test` (or the individual webpack tasks) to break when an undocumented var is found, it does show a nice, coloured warning for you to act on.