### PR TITLE
left-over mentions of teach.moz that should have been made learning.moz

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,8 @@ changes haven't introduced any [Mixed Content][] warnings.
 
 [attaching]: https://github.com/blog/1347-issue-attachments
 [screenshot]: https://www.google.com/search?q=how+to+take+a+screenshot
-[README]: https://github.com/mozilla/teach.mozilla.org#readme
-[CHANGELOG]: https://github.com/mozilla/teach.mozilla.org/blob/develop/CHANGELOG.md
+[README]: https://github.com/mozilla/learning.mozilla.org#readme
+[CHANGELOG]: https://github.com/mozilla/learning.mozilla.org/blob/develop/CHANGELOG.md
 [js]: https://github.com/MozillaFoundation/javascript-style-guide
 [synonym]: https://help.github.com/articles/closing-issues-via-commit-messages
 [PageSpeed Insights]: https://developers.google.com/speed/pagespeed/insights/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 ## Release Process
 
 This documents the process for issuing and deploying a new
-release for teach.mozilla.org.
+release for learning.mozilla.org.
 
 It assumes the following:
 
@@ -36,7 +36,7 @@ After running this `changelog release` command, run through the following steps:
 
     ```
     git checkout -b v0.0.4-rc develop
-    git push -u https://github.com/toolness/teach.mozilla.org.git v0.0.4-rc
+    git push -u https://github.com/toolness/learning.mozilla.org.git v0.0.4-rc
     ```
 
 3.  [Issue a PR][pr] to merge your branch into `master` titled
@@ -83,19 +83,19 @@ After running this `changelog release` command, run through the following steps:
 
     ```
     git tag -a v0.0.4 -F tag-message-v0.0.4.txt
-    git push https://github.com/mozilla/teach.mozilla.org.git v0.0.4   
+    git push https://github.com/mozilla/learning.mozilla.org.git v0.0.4   
     ```
 
 10. Merge `v0.0.4-rc` into `develop` on the official repository:
 
     ```
     git checkout develop
-    git pull https://github.com/mozilla/teach.mozilla.org.git develop
+    git pull https://github.com/mozilla/learning.mozilla.org.git develop
     git merge v0.0.4-rc
-    git push https://github.com/mozilla/teach.mozilla.org.git develop
+    git push https://github.com/mozilla/learning.mozilla.org.git develop
     ```
 
 Hooray, you're done!
 
-[unreleased]: https://github.com/mozilla/teach.mozilla.org/blob/develop/CHANGELOG.md#unreleased
-[pr]: https://github.com/mozilla/teach.mozilla.org/compare/master...toolness:v0.0.4-rc
+[unreleased]: https://github.com/mozilla/learning.mozilla.org/blob/develop/CHANGELOG.md#unreleased
+[pr]: https://github.com/mozilla/learning.mozilla.org/compare/master...toolness:v0.0.4-rc

--- a/components/dev-ribbon.jsx
+++ b/components/dev-ribbon.jsx
@@ -91,7 +91,7 @@ var DevModal = React.createClass({
         <a href="http://invis.io/9G2DK7SR2" target="_blank" className="btn btn-block">
           <span className="glyphicon glyphicon glyphicon-plane"/> Site Map
         </a>
-        <a href="https://github.com/mozilla/teach.mozilla.org/issues" target="_blank" className="btn btn-block">
+        <a href="https://github.com/mozilla/learning.mozilla.org/issues" target="_blank" className="btn btn-block">
           <span className="glyphicon glyphicon glyphicon-exclamation-sign"/> File An Issue on GitHub
         </a>
         <a href={TeachAPI.getDefaultURL()} target="_blank" className="btn btn-block">
@@ -106,7 +106,7 @@ var DevModal = React.createClass({
 
         <br/>
         <p><small>
-          For hints on manual testing and more, please see the <a href="https://github.com/mozilla/teach.mozilla.org/blob/develop/CONTRIBUTING.md">Contribution Guidelines</a>.
+          For hints on manual testing and more, please see the <a href="https://github.com/mozilla/learning.mozilla.org/blob/develop/CONTRIBUTING.md">Contribution Guidelines</a>.
         </small></p>
       </Modal>
     );

--- a/components/optimizely-subdomain.jsx
+++ b/components/optimizely-subdomain.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 
 var optimizelyActive = process.env.OPTIMIZELY_ACTIVE === 'yes';
-var cookieDomain = process.env.FULL_SUBDOMAIN_FOR_COOKIE || 'teach.mozilla.org';
+var cookieDomain = process.env.FULL_SUBDOMAIN_FOR_COOKIE || 'learning.mozilla.org';
 
 var OptimizelySubdomain = React.createClass({
   cookieScript: function() { 

--- a/hoc/with-teach-api.jsx
+++ b/hoc/with-teach-api.jsx
@@ -1,6 +1,6 @@
 // This is a Higher Order Component that can wrap any Component such that
 // it receives a teachAPI property for communicating with the teach-api
-// server that runs in conjunction with the teach.mozilla.org site.
+// server that runs in conjunction with the learning.mozilla.org site.
 //
 // Its use is straight-forward:
 //

--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -38,7 +38,7 @@ var pages = {
   'activities/back-to-school-write-the-web': require('../pages/back-to-school-write-the-web.jsx'),
   'clubs': require('../pages/clubs/index.jsx'),
   'clubs/list': require('../pages/clubs-list.jsx'),
-  // NOTE: 'codemoji' is reserved. See https://github.com/mozilla/teach.mozilla.org/issues/1798
+  // NOTE: 'codemoji' is reserved. See https://github.com/mozilla/learning.mozilla.org/issues/1798
   'community': require('../pages/community.jsx'),
   'community/curriculum-workshop': require('../pages/curriculum-workshop.jsx'),
   'community/curriculum-workshop/march-8-2016': require('../pages/curriculum-workshop-march-8-2016.jsx'),
@@ -52,7 +52,7 @@ var pages = {
   'community/community-call/may-25-2016': require('../pages/community-call-may-25.jsx'),
   'community/community-call/june-29-2016': require('../pages/community-call-june-29.jsx'),
   'community/community-call/july-28-2016': require('../pages/community-call-july-28.jsx'),
-  // NOTE: 'encryption' is reserved. See https://github.com/mozilla/teach.mozilla.org/issues/1798
+  // NOTE: 'encryption' is reserved. See https://github.com/mozilla/learning.mozilla.org/issues/1798
   'events': require('../pages/events.jsx'),
   'events/resources': require('../pages/event-resources.jsx'),
   'fixme': require('../pages/fixme.jsx'),

--- a/lib/stub-blog-feed-loader.js
+++ b/lib/stub-blog-feed-loader.js
@@ -3,7 +3,7 @@ var FAKE_POSTS = {
     "title": "What’s next for Thimble?",
     "author": "Hannah Kane",
     "publishedDate": "Tue, 12 May 2015 10:47:33 -0700",
-    "contentSnippet": "Last week we announced that Thimble will soon be moving over to our new site for people who teach the web, teach.mozilla.org. We also shared that Professor David Humphrey and a team of students from Seneca College have been working to make Thimble an even more powerful teaching, learning, and development tool.\nWe wanted to follow up with more specifics about what you can expect from the new Thimble:\n\nOver the next...",
+    "contentSnippet": "Last week we announced that Thimble will soon be moving over to our new site for people who teach the web, learning.mozilla.org. We also shared that Professor David Humphrey and a team of students from Seneca College have been working to make Thimble an even more powerful teaching, learning, and development tool.\nWe wanted to follow up with more specifics about what you can expect from the new Thimble:\n\nOver the next...",
     "link": "https://blog.webmaker.org/whats-next-for-thimble"
   },
   "latestPosts": [

--- a/pages/healthcheck.jsx
+++ b/pages/healthcheck.jsx
@@ -17,23 +17,23 @@ var HealthcheckMeta = React.createClass({
                     based on version{' '}
                     <code>
                       <a target="_blank"
-                         href={"https://github.com/mozilla/teach.mozilla.org/releases/tag/v" + packageJSON.version}>
+                         href={"https://github.com/mozilla/learning.mozilla.org/releases/tag/v" + packageJSON.version}>
                         {packageJSON.version}
                       </a>
                     </code>
                   </span>;
     return (
       <div>
-        <span>This is a {process.env.NODE_ENV || 'development'} version of the <a href="https://github.com/mozilla/teach.mozilla.org" target="_blank">Teach Site</a> </span>
+        <span>This is a {process.env.NODE_ENV || 'development'} version of the <a href="https://github.com/mozilla/learning.mozilla.org" target="_blank">Teach Site</a> </span>
         { this.state.rev ?
           <span>
             based on commit{' '}
             <code>
-              <a target="_blank" href={"https://github.com/mozilla/teach.mozilla.org/commit/"+this.state.rev} className="commit">{this.state.rev.slice(0,10)}</a>
+              <a target="_blank" href={"https://github.com/mozilla/learning.mozilla.org/commit/"+this.state.rev} className="commit">{this.state.rev.slice(0,10)}</a>
             </code>,
             which is {version} (potentially with <a
               target="_blank"
-              href={"https://github.com/mozilla/teach.mozilla.org/compare/v" +
+              href={"https://github.com/mozilla/learning.mozilla.org/compare/v" +
                     packageJSON.version + "..." + this.state.rev}>
                 changes
               </a>).

--- a/pages/placeholder.jsx
+++ b/pages/placeholder.jsx
@@ -12,12 +12,12 @@ var PlaceholderPage = React.createClass({
         <h2>This is a placeholder page for &ldquo;{this.props.title}&rdquo;.</h2>
         {this.props.githubIssue
          ? <p>Discussion about this page can be found on GitHub at <a
-             href={"https://github.com/mozilla/teach.mozilla.org/issues/" +
+             href={"https://github.com/mozilla/learning.mozilla.org/issues/" +
                    this.props.githubIssue}>
                <code style={{
                  color: '#1F93D0',
                  backgroundColor: '#f0f0f0'
-               }}>mozilla/teach.mozilla.org#{this.props.githubIssue}</code>
+               }}>mozilla/learning.mozilla.org#{this.props.githubIssue}</code>
              </a>.
            </p>
          : null}

--- a/pages/web-lit-basics-two.jsx
+++ b/pages/web-lit-basics-two.jsx
@@ -43,7 +43,7 @@ var curriculumList = [
       {
         title: "Project Playlist",
         image1x: "/img/pages/web-lit-basics-two/project-playlist.png",
-        originalImgSrc: "https://teach.mozilla.org",
+        originalImgSrc: "https://learning.mozilla.org",
         caption: "CC-BY MLN",
         subtitle: "Understanding Composing",
         description: "Learners will build a playlist of songs from the Open Web, learning <strong>composing and remixing</strong>.",
@@ -61,7 +61,7 @@ var curriculumList = [
       {
         title: "Pixel Portrait",
         image1x: "/img/pages/web-lit-basics-two/pixel-portrait.png",
-        originalImgSrc: "https://teach.mozilla.org",
+        originalImgSrc: "https://learning.mozilla.org",
         caption: "CC-BY MLN",
         subtitle: "Understanding Composing",
         description: "Learners will create their own pixel art, import it into an online code editor, and then insert it into a webpage, learning <strong>composing</strong>.",
@@ -70,7 +70,7 @@ var curriculumList = [
       {
         title: "#allthestickerz",
         image1x: "/img/pages/web-lit-basics-two/allthestickerz.png",
-        originalImgSrc: "https://teach.mozilla.org",
+        originalImgSrc: "https://learning.mozilla.org",
         caption: "CC-BY MLN",
         subtitle: "Understanding Sharing",
         description: "Learners will create pixel art online/digital stickers, publish them for others, and use them to annotate and remix the Web, learning <strong>community participation, composing, open practices, remix, and sharing</strong>.",


### PR DESCRIPTION
There were quite a few instances of `teach.mozilla.org` that should now be `learning.mozilla.org`, however there are some instances that cannot be replaced.

@hannahkane: there are links to logoassets.jsx and tabs.jsx that point to `https://stuff.webmaker.org/teach.mozilla.org` resources, renaming of which requires we actually change links on the web. Do we want to do that, or do we just keep those URLs and have some historical baggage in our files?