### PR TITLE
source mapping for the server.library.js bundle

### DIFF
--- a/config/webpack/webpack.server.config.js
+++ b/config/webpack/webpack.server.config.js
@@ -9,6 +9,7 @@ var webpack = require('webpack');
 
 var webpackConfig = {
   entry: __dirname + '/../../lib/build/server.library.jsx',
+  devtool: 'source-map',
   target: 'node',
   externals: function(context, request, callback) {
     // bundle in relative script requires.
@@ -36,6 +37,9 @@ var webpackConfig = {
       }
     ]
   },
+  plugins: [
+    new webpack.BannerPlugin('require("source-map-support").install();', { raw: true, entryOnly: false })    
+  ],
   output: {
     library: 'true',
     libraryTarget: 'commonjs2',


### PR DESCRIPTION
Super handy when trying to figure out what on earth is going on when there's a server error rather than client error.

This now generates a `build/server.library.js` file that has all the source mapping to tell you that an error occurred in, for instance, page.jsx line 162, rather than in server.library.js line something-thousand-something-hundred pointing to the start of a massive bundle entry.