### PR TITLE
allow img-src data uris, and clear goggles for use on learning.moz

### DIFF
--- a/server/security-headers.js
+++ b/server/security-headers.js
@@ -19,7 +19,9 @@ var securityHeaders = {
       'cdn.optimizely.com',
       'https://www.google.com',
       'https://s.ytimg.com',
-      'https://www.mozilla.org'
+      'https://www.mozilla.org',
+      'https://goggles.mofostaging.net',
+      'https://goggles.mozilla.org'      
     ],
     fontSrc: [
       '\'self\'',
@@ -37,6 +39,7 @@ var securityHeaders = {
     imgSrc: [
       '\'self\'',
       '\'unsafe-inline\'',
+      'data:',
       '*'
     ],
     connectSrc: [
@@ -49,7 +52,9 @@ var securityHeaders = {
       '*.makes.org',
       'bitly.mofoprod.net',
       process.env.TEACH_API_URL || 'https://teach-api-staging.herokuapp.com',
-      url.parse(process.env.NEWSLETTER_MAILINGLIST_URL || 'https://basket-dev.allizom.org').hostname
+      url.parse(process.env.NEWSLETTER_MAILINGLIST_URL || 'https://basket-dev.allizom.org').hostname,
+      'https://goggles.mofostaging.net',
+      'https://goggles.mozilla.org'          
     ]
   },
   reportOnly: false,

--- a/server/security-headers.js
+++ b/server/security-headers.js
@@ -21,7 +21,7 @@ var securityHeaders = {
       'https://s.ytimg.com',
       'https://www.mozilla.org',
       'https://goggles.mofostaging.net',
-      'https://goggles.mozilla.org'      
+      'https://goggles.mozilla.org'
     ],
     fontSrc: [
       '\'self\'',
@@ -54,7 +54,7 @@ var securityHeaders = {
       process.env.TEACH_API_URL || 'https://teach-api-staging.herokuapp.com',
       url.parse(process.env.NEWSLETTER_MAILINGLIST_URL || 'https://basket-dev.allizom.org').hostname,
       'https://goggles.mofostaging.net',
-      'https://goggles.mozilla.org'          
+      'https://goggles.mozilla.org'
     ]
   },
   reportOnly: false,


### PR DESCRIPTION
fixes #2176 by added `data:` as permitted image source, and adding goggles (via https only) to our script source/connect source whitelists.