### PR TITLE
bump mofoui to ^1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "minimist": "^1.2.0",
     "mofo-localize": "^0.1.1",
     "mofo-style": "^2.4.0",
-    "mofo-ui": "1.5.1",
+    "mofo-ui": "^1.6.0",
     "moment": "^2.10.3",
     "mozilla-tabzilla": "^0.5.1",
     "npm-run-all": "^3.0.0",


### PR DESCRIPTION
updates mofo-ui to `^1.6.0` so we stay up to date