### PR TITLE
add http status 200 tests

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -38,6 +38,8 @@ describe('App.js server testing', function() {
       request
       .get(serveraddress + locale + '/')
       .end(function(_err, res){
+        res.status.should.equal(200);
+
         var dom = jsdom.env(res.text, function (err, window) {
           if (err) {
             throw new Error(err);
@@ -57,6 +59,8 @@ describe('App.js server testing', function() {
       request
       .get(serveraddress + locale + '/healthcheck')
       .end(function(_err, res){
+        res.status.should.equal(200);
+
         var dom = jsdom.env(res.text, function (err, window) {
 
           if (err) {


### PR DESCRIPTION
Make sure that the page requests from the app.js server are in fact HTTP status 200, so that we can catch the server "not working".