### PR TITLE
quick fix to maker party tabs

### DIFF
--- a/components/events/events-nav.jsx
+++ b/components/events/events-nav.jsx
@@ -10,11 +10,11 @@ var EventsNav = React.createClass({
     return (
       <div className="inner-container">
         <div className="mui-tab-switcher">
-          <div className="tabs">
-            <Link className="btn" activeClassName="active" to={"/" + this.context.intl.locale + "/events"}>
+          <div className="mui-tabs">
+            <Link className="mui-btn" activeClassName="mui-active" to={"/" + this.context.intl.locale + "/events"}>
               {this.context.intl.formatMessage({id: 'overview'})}
             </Link>
-            <Link className="btn" activeClassName="active" to={"/" + this.context.intl.locale + "/events/resources"}>
+            <Link className="mui-btn" activeClassName="mui-active" to={"/" + this.context.intl.locale + "/events/resources"}>
               {this.context.intl.formatMessage({id: 'host_resources'})}
             </Link>
           </div>

--- a/less/pages/events.less
+++ b/less/pages/events.less
@@ -10,6 +10,11 @@
   .secondary-button {
     display: inline-block;
   }
+  font-size: 18px;
+  .mui-btn {
+    line-height: inherit;
+    text-decoration: none;
+  }
 }
 
 .events {


### PR DESCRIPTION
@gvn so Initially, I needed a tab navigation functionality, that looked like the clubs nav.

I didn't see the clubs nav working with routes, so I just did the quickest thing (we needed it on pontoon asap, so the link needed to function, not look good) which was just some `<Link>` elements and stole some css. Seemed to work fine, but was fragile.

Not surprisingly the events nav broke. I noticed there were some changes to the classNames in way mofo-ui tab switcher, which is fine, and I updated the classNames in my quick implementation, and that's all this PR is addressing. The Nav looks good again.

However, I did notice that the clubs page seems to be using routes in the nav somehow, and I think I need a more stable solution for my nav so it doesn't break again. Thoughts I have or ideas for a future patch would be:

1. Are you open to changes to the clubs nav UI to just be some css and some `<Link>` elements? Or is there something a little more complex going on in the `TabSwitcher` that prevents this?
2. I update my page to be more like clubs, but I'm actually confused as to how the `TabSwitcher` works.
3. Do nothing. Maybe you don't plan on updating the css in the `TabSwitcher`, but this is unlikely, and not a great option.
4. I freeze the css in another css file so if you make changes to `TabSwitcher` the maker party page stay the same. Also not a great option.

I like options 1 and 2 best. 3 and 4 are hacks. Thoughts?
