### PR TITLE
twitter and facebook plain-link sharing

### DIFF
--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -234,16 +234,26 @@ var BadgePage = React.createClass({
     );
   },
 
+  getShareCodes: function() {
+    var url = encodeURIComponent(window.location.toString());
+    var msg = encodeURIComponent(`I earned the Mozilla ${this.state.badge.title} badge`);
+
+    return (
+      <div className="social-share">
+        <a href={`https://twitter.com/home?status=${msg + encodeURIComponent(': ') + url}`} target={'_blank'}>facebook</a>
+        <a href={`http://www.facebook.com/sharer.php?u=${url}&t=${msg}`} target={'_blank'}>twitter</a>
+      </div>
+    );
+  },
+
   renderAchieved: function() {
     var badgeCriteria = this.formBadgeCriteria(this.state.badge.criteria);
-    var share = null; // <SocialShare />
 
-    // FIXME: TODO: retrieve the information on when/how this badge was earned.
-    //              ... IF we use this information at all.
+    // FIXME: TODO: retrieve the information on when/how this badge was earned... IF we use this information at all.
     return (
       <div className="badge-achieved">
         <h3 className={'text-light'}>Congrats, you were awarded this credential.</h3>
-        { share }
+        { this.getShareCodes() }
         <div className="badge-reward-text">
           <div className="date">
             DATE FROM API (although we may not end up using this);
@@ -275,7 +285,6 @@ var BadgePage = React.createClass({
       </div>
     );
   },
-
 
   renderEligible: function() {
     var badgeCriteria = this.formBadgeCriteria(this.state.badge.criteria);

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -240,8 +240,8 @@ var BadgePage = React.createClass({
 
     return (
       <div className="social-share">
-        <a href={`https://twitter.com/home?status=${msg + encodeURIComponent(': ') + url}`} target={'_blank'}>facebook</a>
-        <a href={`http://www.facebook.com/sharer.php?u=${url}&t=${msg}`} target={'_blank'}>twitter</a>
+        <a href={`https://twitter.com/home?status=${msg + encodeURIComponent(': ') + url}`} target={'_blank'}>twitter</a>
+        <a href={`https://www.facebook.com/sharer.php?u=${url}&t=${msg}`} target={'_blank'}>facebook</a>
       </div>
     );
   },


### PR DESCRIPTION
fixes https://github.com/mozilla/learning.mozilla.org/issues/2154 although for the moment this PR stubs out the share links but we need to:

- [ ] style these to look nice (fb/tw icons?)
- [ ] tweak the copy to be appropriate