### PR TITLE
Remove the static site check for GA

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,17 +1,13 @@
-var IN_STATIC_SITE = (typeof (window) !== 'undefined');
-var GENERATING_STATIC_SITE = !IN_STATIC_SITE;
-var ENABLE_PUSHSTATE = (IN_STATIC_SITE &&
-                        window.history.pushState &&
-                        window.history.replaceState);
+var IN_BROWSER = (typeof (window) !== 'undefined');
+var ENABLE_PUSHSTATE = (IN_BROWSER && window.history.pushState && window.history.replaceState);
 var DEV_SERVER_PORT = 8008;
 var ORIGIN;
 var locales = require('../dist/locales.json');
 
-if (IN_STATIC_SITE) {
+if (IN_BROWSER) {
   ORIGIN = window.location.protocol + '//' + window.location.host;
 } else {
   ORIGIN = process.env.ORIGIN;
-
   if (!ORIGIN) {
     if (process.env.NODE_ENV === 'production') {
       throw new Error('ORIGIN must be defined in production.');
@@ -26,10 +22,8 @@ exports.ENABLE_BADGES = !!process.env.ENABLE_BADGES;
 exports.ENABLE_PUSHSTATE = ENABLE_PUSHSTATE;
 exports.ENCRYPT_CAMPAIGN_URL = "https://mzl.la/encrypt";
 exports.FLICKR_MAKER_PARTY = 'https://www.flickr.com/photos/mozilladrumbeat/sets/72157654235131834/';
-exports.GENERATING_STATIC_SITE = GENERATING_STATIC_SITE;
 exports.GIGABIT_SITE_LINK = 'https://mozilla.org/gigabit';
 exports.HIVE_LEARNING_NETWORKS_URL = 'https://hivelearningnetworks.org';
-exports.IN_STATIC_SITE = IN_STATIC_SITE;
 exports.IN_TEST_SUITE = (typeof describe === 'function');
 exports.LIGHT_BEAM_URL = "https://addons.mozilla.org/firefox/downloads/latest/363974/addon-363974-latest.xpi";
 exports.MAKE_METADATA_URL = process.env.MAKE_METADATA_URL || 'https://{username}.makes.org/makes.json';

--- a/lib/build/client.bundle.jsx
+++ b/lib/build/client.bundle.jsx
@@ -32,7 +32,8 @@ if (GA_ACCOUNT) {
   ga.initialize(GA_ACCOUNT, { debug: GA_DEBUG === 'on' });
 }
 
-// Start running the site client-side if JS is available
+// Run the bundle, possibly after bootstrapping window.Intl
+// if that has not been bootstrapped yet.
 if (!window.Intl) {
   require.ensure(['intl'], function(require) {
     window.Intl = require('intl');

--- a/lib/build/client.bundle.jsx
+++ b/lib/build/client.bundle.jsx
@@ -28,22 +28,20 @@ function startRunningSite() {
   generator.run(history, pageHolder);
 }
 
-// flip the "using JS" switch and start to perform GA accordingly
-if (config.IN_STATIC_SITE) {
-  if (GA_ACCOUNT) {
-    ga.initialize(GA_ACCOUNT, { debug: GA_DEBUG === 'on' });
-  }
-
-  // Start running the site client-side if JS is available
-  if (!window.Intl) {
-    require.ensure(['intl'], function(require) {
-      window.Intl = require('intl');
-      startRunningSite();
-    }, "IntlBundle");
-  } else {
-    startRunningSite();
-  }
+if (GA_ACCOUNT) {
+  ga.initialize(GA_ACCOUNT, { debug: GA_DEBUG === 'on' });
 }
+
+// Start running the site client-side if JS is available
+if (!window.Intl) {
+  require.ensure(['intl'], function(require) {
+    window.Intl = require('intl');
+    startRunningSite();
+  }, "IntlBundle");
+} else {
+  startRunningSite();
+}
+
 
 // Add in the developer ribbon when not in production mode.
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
This should simply always enable google analytics and initialize it (if there is a GA_ACCOUNT value set) for the client code.