### PR TITLE
Fix for events page hero unit positon, so something is visible for mo…

### DIFF
--- a/less/pages/events.less
+++ b/less/pages/events.less
@@ -2,6 +2,7 @@
 .page.event-resources {
  .hero-unit {
     background-image: url(/img/pages/events/maker-party-hero.png);
+    background-position: 16% top;
 
     .retina2x({
       background-image: url(/img/pages/events/maker-party-hero_2x.png);


### PR DESCRIPTION
Just some QA fix. RIght now, the hero unit image is default to center and top, which means in mobile it looks like this:
![host-tab](https://cloud.githubusercontent.com/assets/197334/18599422/685ca2a4-7c26-11e6-93db-4800642aeebd.png)

Someone's shoulder...

My patch makes it like this on mobile:
![hero](https://cloud.githubusercontent.com/assets/197334/18599467/8c83685c-7c26-11e6-9156-35b45982114b.png)

I cut off the bottom in the screenshot, but should get the idea across.

R?
