### PR TITLE
Fixes #2216 - sign up button on homepage looks janky

### DIFF
--- a/components/newsletter-signup/SignupForm.jsx
+++ b/components/newsletter-signup/SignupForm.jsx
@@ -90,7 +90,7 @@ var SignupForm = React.createClass({
           </div>
           {this.renderValidationErrors()}
         </fieldset>
-        <input type="submit" value={this.context.intl.formatMessage({id: 'sign_up'})} className="btn center-block" />
+        <input type="submit" value={this.context.intl.formatMessage({id: 'sign_up'})} className="btn" />
       </form>
     );
   }


### PR DESCRIPTION
Fixes #2216 

**Changes proposed in this pull request:**

Removes `.center-block` from the sign up button in the homepage. This made the button look poorly styled.

(*Note:* can't add labels, but this **needs review**.)