### PR TITLE
make the clubform reload to the correct view when a user logs in/out

### DIFF
--- a/components/login/Login.jsx
+++ b/components/login/Login.jsx
@@ -79,11 +79,19 @@ var Login = React.createClass({
     this.setState({loggingIn: true});
   },
   handleApiLoginSuccess: function(info) {
-    this.setState({username: this.props.teachAPI.getUsername(), loggingIn: false});
+    this.setState({username: this.props.teachAPI.getUsername(), loggingIn: false}, () => {
+      if (this.props.onLoginChange) {
+        this.props.onLoginChange(true);
+      }
+    });
     ga.event({ category: 'Login', action: 'Logged In' });
   },
   handleApiLogout: function() {
-    this.setState({username: null, loggingIn: false});
+    this.setState({username: null, loggingIn: false}, () => {
+      if (this.props.onLoginChange) {
+        this.props.onLoginChange(false);
+      }
+    });
     ga.event({ category: 'Login', action: 'Logged Out' });
   },
   renderAdminLink: function() {

--- a/pages/clubs/ClubForm.jsx
+++ b/pages/clubs/ClubForm.jsx
@@ -17,15 +17,13 @@ var STEP_SHOW_RESULT = 2;
 var ClubForm = React.createClass({
   statics: {
     pageTitle: "Apply to be a Club Captain",
-    pageClassName: "clubs",
-    teachAPIEvents: {
-      'clubs:change': 'forceUpdate',
-      'username:change': 'forceUpdate'
-    }
+    pageClassName: "clubs"
   },
+
   getInitialState: function() {
     this.clubData = {};
     return {
+      loggedIn: false,
       progress: 0,
       currentStep: 0,
       titles: [
@@ -62,7 +60,7 @@ var ClubForm = React.createClass({
               <h2>{ username ? this.state.headings[this.state.currentStep] : this.state.loginHeading }</h2>
             </Illustration>
           </section>
-          { username ? this.renderSteps() : this.renderLoginRequest() }
+          { this.state.loggedIn ? this.renderSteps() : this.renderLoginRequest() }
         </div>
       </div>
     );
@@ -118,9 +116,14 @@ var ClubForm = React.createClass({
           currentPath={this.props.currentPath}
           loginClass="btn"
           signupLabel="Create an account"
+          onLoginChange={this.onLoginChange}
         />
       </div>
     );
+  },
+
+  onLoginChange: function(loggedIn) {
+    this.setState({ loggedIn });
   },
 
   updateProgress: function(progress) {


### PR DESCRIPTION
This adds explicit listening for login/logout status for the application club form, so that we don't see the user menu anymore. The fix involves sending a signal to the owning component so that it can update its state and thus rerender with the appropriate content.

fixes https://github.com/mozilla/learning.mozilla.org/issues/2246

testing: run learning.moz code without any custom `.env` variables, load up [http://localhost:8008/en-US/clubs/apply](http://localhost:8008/en-US/clubs/apply), and then sign in/out -- whenever you change login status, the page should rerender and give you the appropriate content (login if you're logged out, application form if you're logged in)