### PR TITLE
link size fix, labels around radio/checks, outline ZERO, other spacing

### DIFF
--- a/less/pages/clubs-form.less
+++ b/less/pages/clubs-form.less
@@ -4,9 +4,18 @@
     width: 80%;
     margin: auto;
 
+    * {
+      // serious, get out of here, outline.
+      outline: 0 !important;
+    }
+
     .learn-more {
       text-align: center;
       margin: 2em 0;
+    }
+
+    input.controlled {
+      margin-top: 0.5em;
     }
 
     textarea {
@@ -35,7 +44,7 @@
       }
     }
 
-    .pledge {
+    .pledgeAgreement {
       margin-top: 1.5em;
       font-size: 90%;
       a {
@@ -66,6 +75,10 @@
           box-shadow: 0px 0px 2px 1px #F00;
         }
       }
+
+      label {
+        font-weight: normal;
+      }
     }
 
     input[type=checkbox] + span,
@@ -82,7 +95,7 @@
 
       button {
         .btn;
-        
+
         margin: 1rem;
         height: 2.25em;
         line-height: 1;

--- a/pages/clubs/form/builder/Form.jsx
+++ b/pages/clubs/form/builder/Form.jsx
@@ -219,6 +219,7 @@ var Form = React.createClass({
 
     if (shouldFocus) {
       common.ref = 'autofocus';
+      inputClass += " controlled";
     }
 
     if (label) {
@@ -239,9 +240,12 @@ var Form = React.createClass({
     } else if (Type === "textarea") {
       formfield = <textarea className={inputClass} {...common} hidden={shouldHide}/>;
     } else if (Type === "checkbox") {
+      // FIXME: while clickable, this does not seem to tick the checkbox...
       formfield = <div>
-        <input className={inputClass} {...common} type={Type} hidden={shouldHide}/>
-        { label }
+        <label>
+          <input className={inputClass} {...common} type="checkbox" hidden={shouldHide}/>
+          { label }
+        </label>
       </div>;
       label = null;
     } else if (Type === "choiceGroup") {
@@ -252,7 +256,12 @@ var Form = React.createClass({
 
       for (let c=0; c<colCount; c++) {
         let choiceset = choices.slice(c*bracket, (c+1)*bracket).map(value => {
-          return <div key={value}><input className={inputClass} type="radio" name={name} value={value} checked={this.state[name] === value} onChange={common.onChange}/>{value}</div>;
+          return <div key={value}>
+            <label>
+              <input className={inputClass} type="radio" name={name} value={value} checked={this.state[name] === value} onChange={common.onChange}/>
+              {value}
+            </label>
+          </div>;
         });
 
         columns.push(<div key={field.name + 'col' + c} className="column">{choiceset}</div>);
@@ -267,7 +276,12 @@ var Form = React.createClass({
 
       for (let c=0; c<colCount; c++) {
         let choiceset = choices.slice(c*bracket, (c+1)*bracket).map(value => {
-          return <div key={value}><input className={inputClass} type="checkbox" name={name} value={value} checked={this.state[name].indexOf(value)>-1} onChange={common.onChange}/>{value}</div>;
+          return <div key={value}>
+            <label>
+              <input className={inputClass} type="checkbox" name={name} value={value} checked={this.state[name].indexOf(value)>-1} onChange={common.onChange}/>
+              {value}
+            </label>
+          </div>;
         });
 
         columns.push(<div key={field.name + 'col' + c} className="column">{choiceset}</div>);
@@ -280,7 +294,7 @@ var Form = React.createClass({
       formfield = <Type {...field} {...common} className={inputClass} />;
     }
 
-    return <fieldset key={name + 'set'}>{ [label, formfield] }</fieldset>;
+    return <fieldset key={name + 'set'} className={name}>{ [label, formfield] }</fieldset>;
   },
 
   /**


### PR DESCRIPTION
LESS fixes and fixes to `<Form>` to enable styling.

fixes https://github.com/mozilla/learning.mozilla.org/issues/2272
- pledge link font is now the right size

fixes https://github.com/mozilla/learning.mozilla.org/issues/2261
- radio and checkboxes now have a wrapping label

fixes https://github.com/mozilla/learning.mozilla.org/issues/2260
- outline is 0. You hear me, LESS? ZERO.