### PR TITLE
focus on "other" field when it gets revealed

### DIFF
--- a/pages/clubs/form/builder/Form.jsx
+++ b/pages/clubs/form/builder/Form.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 /**
 
@@ -141,6 +142,28 @@ var Form = React.createClass({
     );
   },
 
+  // autofocus on anything that needs autofocussing.
+  componentDidUpdate: function(prevProps, prevState) {
+    var afelement = this.refs.autofocus;
+
+    if (afelement) {
+      afelement = ReactDOM.findDOMNode(afelement);
+      afelement.focus();
+
+      // We need to use the following code to get around
+      // the bizar way in which react-select steals focus,
+      // even when the browser has issued a .focus() on
+      // a completely different HMTL element...
+      function forceFocus() {
+        if (afelement !== document.activeElement) {
+          afelement.focus();
+          setTimeout(forceFocus, 10);
+        }
+      }
+      setTimeout(forceFocus, 100);
+    }
+  },
+
   // This is to be used for updating a progress bar...
   getProgress: function() {
     // get the number of required fields that have a value filled in.
@@ -174,7 +197,7 @@ var Form = React.createClass({
       placeholder: field.placeholder
     };
 
-    var shouldHide = false, choices = false;
+    var shouldHide = false, choices = false, shouldFocus = false;
 
     if (field.controller) {
       var controller = field.controller.name;
@@ -185,6 +208,16 @@ var Form = React.createClass({
       } else {
         shouldHide = this.state[controller] !== controlValue;
       }
+
+      // should we be focussing on this field?
+      if (!shouldHide && !this.state[name]) {
+        shouldFocus = true;
+      }
+    }
+
+    if (shouldFocus) {
+      common.ref = 'autofocus';
+      console.log("setting autofocus for controlled field "+name);
     }
 
     if (label) {
@@ -197,6 +230,8 @@ var Form = React.createClass({
       label = null;
       inputClass += " nolabel";
     }
+
+    inputClass = inputClass.trim();
 
     if (ftype === "undefined" || Type === "text") {
       formfield = <input className={inputClass} type={Type? Type : "text"} {...common} hidden={shouldHide}/>;

--- a/pages/clubs/form/builder/Form.jsx
+++ b/pages/clubs/form/builder/Form.jsx
@@ -217,7 +217,6 @@ var Form = React.createClass({
 
     if (shouldFocus) {
       common.ref = 'autofocus';
-      console.log("setting autofocus for controlled field "+name);
     }
 
     if (label) {


### PR DESCRIPTION
If a selector or radio/checkbox group has an "other" option that the user selects, and this reveals a text field for filling in a custom value, the code will now automatically move focus to this "other" field.

This has a nasty hack that is necessary to deal with `react-select` being a jerk and stealing focus back when the browsers calls `.focus()` on something else. Completely page breaking, so... setTimeout. Yeah.

fixes https://github.com/mozilla/learning.mozilla.org/issues/2256