### PR TITLE
adds oct Curriculum Workshop info

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -51,6 +51,7 @@ var pages = {
   'community/curriculum-workshop/may-10-2016': require('../pages/curriculum-workshop-may-10-2016.jsx'),
   'community/curriculum-workshop/june-16-2016': require('../pages/curriculum-workshop-june-16-2016.jsx'),
   'community/curriculum-workshop/july-12-2016': require('../pages/curriculum-workshop-july-12-2016.jsx'),
+  'community/curriculum-workshop/sept-29-2016': require('../pages/curriculum-workshop-sept-29-2016.jsx'),
   'community/community-call': require('../pages/community-call.jsx'),
   'community/community-call/march-23-2016': require('../pages/community-call-march-23.jsx'),
   'community/community-call/april-20-2016': require('../pages/community-call-april-20.jsx'),

--- a/pages/curriculum-workshop-sept-29-2016.jsx
+++ b/pages/curriculum-workshop-sept-29-2016.jsx
@@ -1,0 +1,63 @@
+var React = require('react');
+var HeroUnit = require('../components/hero-unit.jsx');
+// use this LinkAnchorSwap component for hyperlinks
+var LinkAnchorSwap = require('../components/link-anchor-swap.jsx');
+var Illustration = require('../components/illustration.jsx');
+
+var CurriculumWorkshop = React.createClass({
+  statics: {
+    pageClassName: 'curriculum-workshop',
+    pageTitle: 'Curriculum Workshops'
+  },
+  render: function () {
+    return (
+        <div className="inner-container call-container">
+          <section className="intro intro-after-banner">
+           <Illustration
+             height={175} width={175}
+             src1x="/img/pages/community/svg/icon-circle-community.svg"
+             alt="icon toolkit">
+               <h1>Mozilla Curriculum Workshop</h1>
+               <h2>Join us on the second Tuesday of each month!</h2>
+           </Illustration>
+          </section>
+
+          <p>
+            Co-hosts Amira Dhalla and Chad Sansing, along with producers Kristina Gorr and Paul Oh, help participants answer the question, <em>"How can I use the web to teach and learn what’s important to me?"</em> Join us as we prototype teaching and learning materials live on-air and think out-loud through the curriculum design process.
+          </p>
+
+          <section className="callout-box past-workshop">
+            <h2>Past Workshop</h2>
+            <p className="date">September 29th - 7am PT / 10am ET / 2pm UTC</p>
+            <h1>Maker Party & Copyright</h1>
+          </section>
+
+          <p>
+           Join us on September 29th as co-hosts Amira Dhalla and Chad Sansing and invited guests dig into this year’s Maker Party campaign around copyright and political action, especially in the EU. Learn about the copyright reform issues at play in Europe and how they connect to - or might impact - your local community and others around the world. Help us develop teaching and learning materials that make copyright, open licensing, and public domain clear and compelling to learners wherever you live.
+          </p>
+
+          <p>
+            You can also join the discussion on <LinkAnchorSwap to="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</LinkAnchorSwap> or <LinkAnchorSwap to="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</LinkAnchorSwap>.
+          </p>
+
+          <h3>Workshop Video Stream</h3>
+
+          <div className="video-wrapper">
+            <iframe className="workshop-video" width="560" height="315" src="//www.youtube.com/embed/uIh91sa4K4k" frameBorder="0" allowFullScreen></iframe>
+          </div>
+
+          <h4>
+            Open Agenda
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-september-13-2016">
+            </a>
+          </h4>
+
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-september-13-2016"></iframe>
+
+
+        </div>
+    );
+  }
+});
+
+module.exports = CurriculumWorkshop;

--- a/pages/curriculum-workshop.jsx
+++ b/pages/curriculum-workshop.jsx
@@ -28,12 +28,12 @@ var CurriculumWorkshop = React.createClass({
 
           <section className="callout-box">
             <h2>Upcoming Workshop</h2>
-            <p className="date">September 29th - 7am PT / 10am ET / 2pm UTC</p>
-            <h1>Maker Party & Copyright</h1>
+            <p className="date">October 11th - 6 AM PT, 9 AM ET, 1 PM UTC</p>
+            <h1>Ada Lovelace Day</h1>
           </section>
 
           <p>
-           Join us on September 29th as co-hosts Amira Dhalla and Chad Sansing and invited guests dig into this year’s Maker Party campaign around copyright and political action, especially in the EU. Learn about the copyright reform issues at play in Europe and how they connect to - or might impact - your local community and others around the world. Help us develop teaching and learning materials that make copyright, open licensing, and public domain clear and compelling to learners wherever you live.
+           <a href="https://en.wikipedia.org/wiki/Ada_Lovelace">Ada Lovelace</a> is largely regarded as the first computer programmer, and her work and skills exemplified strength in STEM as she worked on the analytic engine, also known as an early mechanical general-purpose computer. Her work ethic and diligence in the field is an inspiration for women is to be celebrated and shared around the world. In our webcast this month, we’ll be recognizing the challenges, accomplishments and contributions of women leaders from the Mozilla Leadership Network around the globe. Join us to help build teaching and learning resources promoting women and the web.
           </p>
 
           <p>
@@ -47,17 +47,17 @@ var CurriculumWorkshop = React.createClass({
           </p>
           <h4>
             Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-september-13-2016">
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-october-11-2016">
             </a>
           </h4>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-september-13-2016"></iframe>
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-october-11-2016"></iframe>
 
           <h2>Upcoming Workshops</h2>
 
           <ul className="upcoming-workshops">
             <li>
-              <p className="date">October 2016 </p>
+              <p className="date">November 2016 </p>
               <h2>TBD</h2>
             </li>
           </ul>
@@ -65,6 +65,16 @@ var CurriculumWorkshop = React.createClass({
           <h2>Past Workshops</h2>
 
           <ul className="past-workshops">
+            <li>
+              <p className="date">September 29th, 2016</p>
+              <h2>Maker Party & Copyright</h2>
+              <p>
+                Join us on September 29th as co-hosts Amira Dhalla and Chad Sansing and invited guests dig into this year’s Maker Party campaign around copyright and political action, especially in the EU. Learn about the copyright reform issues at play in Europe and how they connect to - or might impact - your local community and others around the world. Help us develop teaching and learning materials that make copyright, open licensing, and public domain clear and compelling to learners wherever you live.
+              </p>
+              <p className="watch-archive">
+                <LinkAnchorSwap to="/community/curriculum-workshop/sept-29-2016/">Watch the Replay</LinkAnchorSwap>
+              </p>
+            </li>
             <li>
               <p className="date">July 12th, 2016</p>
               <h2>Brokering Web Literacy Learning Around the World</h2>


### PR DESCRIPTION
- [X] Localization addressed - NA

Fixes #2239

**Changes proposed in this pull request:**
- updates Mozilla Curriculum Workshop with October call info, and adds link to...
- new archive page for September call
- new route for Sept archive page


