### PR TITLE
Turn on maker party link in navigation.

### DIFF
--- a/components/sidebar/topLevelNavItems.jsx
+++ b/components/sidebar/topLevelNavItems.jsx
@@ -32,12 +32,10 @@ var MENU_ENTRIES = [
         name: "mozilla_clubs",
         to: '/clubs'
       },
-      /*
       {
         name: "maker_party",
         to: '/events'
       },
-      */
       {
         name: "hive_learning_networks",
         to: config.HIVE_LEARNING_NETWORKS_URL


### PR DESCRIPTION
This just turns on Maker Party links in the nav, when we're ready to ship.