### PR TITLE
Fix #2313 - Badge details not loading due to accessing incorrect credly property

### DIFF
--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -133,8 +133,10 @@ var BadgePage = React.createClass({
     if (data.earned) { status = Badge.achieved; }
     if (data.pending) { status = Badge.pending; }
 
-    var reqs = bdata.require_claim_evidence_description;
-    var matched = reqs.match(/((\d+(\.)?)?[^.]+)/g);
+    var evidenceRegex = /((\d+([.\!?])?)?[^.]+)/g;
+    var criteriaRegex = /[\n\r]+/g;
+    var criteria = bdata.criteria.length > 0 ? bdata.criteria.trim().split(criteriaRegex) : [];
+    var evidence = bdata.require_claim_evidence_description.match(evidenceRegex) || [];
 
     this.setState({
       badge: {
@@ -143,8 +145,10 @@ var BadgePage = React.createClass({
         description: bdata.short_description,
         icon: bdata.image_url,
         icon2x: bdata.image_url,
-        criteria: matched,
-        status: status
+        criteria,
+        evidence,
+        date_achieved: bdata.created_at,
+        status
       },
       prev: prev,
       next: next


### PR DESCRIPTION
This will allow you to load eligible badges based on what the issue described.

I haven't touched "Achieved" or "Pending" badges because right now it shows some hard-coded text. But I don't know what the HTML is that needs to go there (maybe @Pomax can advise). Accordingly, for the data that I think will be used there, I have left that regex pattern alone but have separated it out from the criteria to apply for a badge regex.