### PR TITLE
Adding a link to events resources page to download.

### DIFF
--- a/locales/en-US/event-resources.properties
+++ b/locales/en-US/event-resources.properties
@@ -50,3 +50,4 @@ hosting_list_3=Facilitation: Making people feel welcome and excited to engage.
 hosting_list_4=Debrief: Reflecting and sharing with Mozilla what you achieved and learned.
 get_host_pack=Get your host pack
 trademark=Please refer to the Mozilla brand guidelines when using the <a href="https://www.mozilla.org/styleguide/identity/mozilla/branding/">Mozilla trademark</a>.
+get_stickers=Planning a Maker Party in the EU? Order stickers for your event <a href="https://docs.google.com/a/mozilla.com/forms/d/14zPnrNun7TUmMySx7t7ugbNCSbNl9dhK7O5oYqUL8Y0/viewform?edit_requested=true">here</a>. 

--- a/pages/event-resources/EventsResources.jsx
+++ b/pages/event-resources/EventsResources.jsx
@@ -267,6 +267,7 @@ var EventsResources = React.createClass({
                 </LogoAssetLink>
               </LogoAsset>
             </div>
+            <FormattedHTMLMessage id='get_stickers'/>
           </section>
 
 


### PR DESCRIPTION
Fixes https://github.com/MozillaFoundation/Advocacy/issues/564#issuecomment-253276982

This adds a link to allow stickers to be ordered. More context can be found in the above ticket, and any issues you have around the copy/design/l01n should also be brought up in the above ticket.

@alanmoo mind doing a quick review?