### PR TITLE
Badge prefil link email

### DIFF
--- a/components/badges/CredlyLinkForm.jsx
+++ b/components/badges/CredlyLinkForm.jsx
@@ -4,14 +4,22 @@ var _ = require('underscore');
 
 var CredlyLinkForm = React.createClass({
   mixins: [LinkedStateMixin],
+
   getInitialState: function() {
     return {
       email: "",
       password: "",
       validationErrors: [],
       pending: false,
-      addendum: ""
+      addendum: "",
+      teachAPI: this.props.teachAPI
     };
+  },
+
+  componentWillMount: function() {
+    this.state.teachAPI.getEmail((email) => {
+      this.setState({ email: email || "" });
+    });
   },
 
   handleSubmit: function(e) {
@@ -60,13 +68,17 @@ var CredlyLinkForm = React.createClass({
         { this.state.addendum ? this.state.addendum : null}
 
         <fieldset>
-          <label className="sr-only">email</label>
-          <input name="email" type="email" size="30" placeholder="email@example.com" valueLink={this.linkState("email")} required />
+          <label>
+            email
+            <input name="email" type="email" size="30" placeholder="email@example.com" valueLink={this.linkState("email")} required placeholder="the email address we should register you on Credly with."/>
+          </label>
         </fieldset>
 
         <fieldset>
-          <label className="sr-only">password</label>
-          <input name="password" type="password" size="30" valueLink={this.linkState("password")} required />
+          <label>
+            password
+            <input name="password" type="password" size="30" valueLink={this.linkState("password")} required placeholder="This will become your Credly password." />
+          </label>
         </fieldset>
 
         <p className="pp-note">

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -72,17 +72,13 @@ _.extend(TeachAPI.prototype, {
     }
   },
   getEmail: function(cb) {
-    var errMail = {
-      email: false
-    };
-
     // This is not allowed to be persistent information
     request.get(this.baseURL + '/auth/email')
       .withCredentials()
       .accept('json')
       .end(function(err, res) {
         if (err) {
-          return errMail;
+          return cb("");
         }
         cb(res.body.email);
       });

--- a/lib/teach-api.js
+++ b/lib/teach-api.js
@@ -71,6 +71,22 @@ _.extend(TeachAPI.prototype, {
       return null;
     }
   },
+  getEmail: function(cb) {
+    var errMail = {
+      email: false
+    };
+
+    // This is not allowed to be persistent information
+    request.get(this.baseURL + '/auth/email')
+      .withCredentials()
+      .accept('json')
+      .end(function(err, res) {
+        if (err) {
+          return errMail;
+        }
+        cb(res.body.email);
+      });
+  },
   getAdminURL: function() {
     if (emulateLogin) {
       return false;

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -236,7 +236,7 @@ var BadgePage = React.createClass({
             education providers and services, including Mozilla.
             Learn more <a href='https://example.org'>about Credly</a>.
           </p>
-          <CredlyLinkForm linkAccounts={this.linkAccounts} hideModal={this.hideLinkModal}/>
+          <CredlyLinkForm teachAPI={this.state.teachAPI} linkAccounts={this.linkAccounts} hideModal={this.hideLinkModal}/>
         </Modal>
       );
     }


### PR DESCRIPTION
Based on the pending PR for badge followup - the relevant commit is *only* https://github.com/mozilla/learning.mozilla.org/commit/a5acffdce0dedd13f1077e3718207d7f70d73286

checks off the "autofill user email" entry on https://github.com/mozilla/learning.mozilla.org/issues/2346