### PR TITLE
better 'return to badge' styling, and a content switch on application…

### DIFF
--- a/less/pages/badges.less
+++ b/less/pages/badges.less
@@ -288,3 +288,25 @@
     }
   }
 }
+
+
+div.modal-credly{
+  &.error {
+    button.back {
+      background: rgb(234, 0, 0);
+      color: #f5ebeb;
+      box-shadow: 0 .4rem 0 rgb(132, 30, 30),0 .1rem 0 rgba(255,255,255,.5) inset;
+    }
+  }
+  div.modal-body{
+    text-align: center;
+    p{
+      text-align: left;
+      margin-top: 1em;
+    }
+    button.back {
+      margin: 1rem 0;
+      padding: 0.2em 0.5em 0em;
+    }
+  }
+}

--- a/lib/badges-api.js
+++ b/lib/badges-api.js
@@ -124,12 +124,15 @@ BadgesAPI.prototype = {
       .end(function (err, res) {
         if (err) {
           console.log('error', err);
+
           var data;
+
           try {
             data = JSON.parse(res.text);
           } catch (e) {
             data = {};
           }
+
           return callback(err, data);
         }
         callback(false, res.body);

--- a/lib/badges-api.js
+++ b/lib/badges-api.js
@@ -124,7 +124,13 @@ BadgesAPI.prototype = {
       .end(function (err, res) {
         if (err) {
           console.log('error', err);
-          return callback(err, res);
+          var data;
+          try {
+            data = JSON.parse(res.text);
+          } catch (e) {
+            data = {};
+          }
+          return callback(err, data);
         }
         callback(false, res.body);
       });

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -245,7 +245,7 @@ var BadgePage = React.createClass({
           <p>
             Something went wrong with your application for this badge.
             Please let us know what you were doing so that we can
-            look into getting that fixes as soon as possible for you!
+            look into getting that fixed as soon as possible for you!
           </p>
           <button className="btn back" onClick={this.hideApplyModal}>Back to the badge</button>
         </Modal>
@@ -448,7 +448,7 @@ var BadgePage = React.createClass({
     // TODO: improve the UX for when network errors occur, leading to errors
     this.setState({
       canCloseModal: true,
-      applicationError: data
+      applicationError: err ? data : false
     });
   },
 
@@ -466,7 +466,15 @@ var BadgePage = React.createClass({
 
   hideApplyModal: function(evt) {
     this.setState({ showApplyModal: false });
-    this.reloadPage();
+
+    // only do a full page reload on a successful application
+    if (this.state.applicationError) {
+      this.setState({
+        applicationError: false
+      });
+    } else {
+      this.reloadPage();
+    }
   },
 
   linkAccounts: function(email, password, handleLinkResult) {

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -240,7 +240,7 @@ var BadgePage = React.createClass({
 
     if (error) {
       return (
-        <Modal className="modal-credly error folded" hideModal={this.state.canCloseModal? this.hideApplyModal : false}>
+        <Modal className="modal-credly error folded" hideModal={this.state.canCloseModal ? this.hideApplyModal : false}>
           <h3 className="centered">Uh-oh, something went wrong...</h3>
           <p>
             Something went wrong with your application for this badge.
@@ -253,7 +253,7 @@ var BadgePage = React.createClass({
     }
 
     return (
-      <Modal modalTitle="" className="modal-credly folded" hideModal={this.state.canCloseModal? this.hideApplyModal : false}>
+      <Modal modalTitle="" className="modal-credly folded" hideModal={this.state.canCloseModal ? this.hideApplyModal : false}>
         <h3 className="centered">Thanks for applying for this badge!</h3>
         <p>
           We will be reviewing your badge application and evidence as soon as possible.

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -58,12 +58,13 @@ var BadgePage = React.createClass({
     var badgeAPI = new BadgesAPI({ teachAPI: teachAPI });
 
     return {
-      hasAccess: false,
       showLinkModal: false,
+      teachAPI: teachAPI,
+      hasAccess: false,
+      badgeAPI: badgeAPI,
       applying: false,
       showApplyModal: false,
-      teachAPI: teachAPI,
-      badgeAPI: badgeAPI,
+      applicationError: false,
       badge: {
         id: "",
         title: "",
@@ -194,15 +195,7 @@ var BadgePage = React.createClass({
 
   render: function () {
     if (this.state.applying && this.state.showApplyModal) {
-      return (
-        <Modal modalTitle="" className="modal-credly folded" hideModal={this.state.canCloseModal? this.hideApplyModal : false}>
-          <h3 className="centered">Thanks for applying for this badge!</h3>
-          <p>
-            We will be reviewing your badge application and evidence as soon as possible.
-          </p>
-          <input type="submit" className="btn center-block" onClick={this.hideApplyModal} value="Back to my badge"/>
-        </Modal>
-      );
+      return this.showBackToBadgeModal();
     }
 
     var content = null;
@@ -233,6 +226,40 @@ var BadgePage = React.createClass({
         <Divider />
         <Navigation prev={this.state.prev} next={this.state.next} />
       </div>
+    );
+  },
+
+  showBackToBadgeModal: function() {
+    var canClose = this.state.canCloseModal;
+    var error = this.state.applicationError;
+    var disabled = "disabled";
+
+    if (canClose || error) {
+      disabled = null;
+    }
+
+    if (error) {
+      return (
+        <Modal className="modal-credly error folded" hideModal={this.state.canCloseModal? this.hideApplyModal : false}>
+          <h3 className="centered">Uh-oh, something went wrong...</h3>
+          <p>
+            Something went wrong with your application for this badge.
+            Please let us know what you were doing so that we can
+            look into getting that fixes as soon as possible for you!
+          </p>
+          <button className="btn back" onClick={this.hideApplyModal}>Back to the badge</button>
+        </Modal>
+      );
+    }
+
+    return (
+      <Modal modalTitle="" className="modal-credly folded" hideModal={this.state.canCloseModal? this.hideApplyModal : false}>
+        <h3 className="centered">Thanks for applying for this badge!</h3>
+        <p>
+          We will be reviewing your badge application and evidence as soon as possible.
+        </p>
+        <button disabled={disabled} className="btn back" onClick={this.hideApplyModal}>Back to my badge</button>
+      </Modal>
     );
   },
 
@@ -420,7 +447,8 @@ var BadgePage = React.createClass({
   handleClaimRequest: function(err, data) {
     // TODO: improve the UX for when network errors occur, leading to errors
     this.setState({
-      canCloseModal: true
+      canCloseModal: true,
+      applicationError: data
     });
   },
 


### PR DESCRIPTION
This centers the "return to badge" button in the application confirmation dialog, and also adds a context switch so that the modal cannot be closed until the POST request has properly finished - if the POST fails (not-200-return) the content is switch out for an error notice and a request to contact us, with a red button rather than yellow.