### PR TITLE
preserve evidence when application fails

### DIFF
--- a/components/badges/RequirementRow.jsx
+++ b/components/badges/RequirementRow.jsx
@@ -7,10 +7,17 @@ var RequirementRow = React.createClass({
     icon: React.PropTypes.oneOfType([
       React.PropTypes.bool,
       React.PropTypes.string
-    ])
+    ]),
+    data: React.PropTypes.object
   },
 
   getInitialState: function() {
+    let data = this.props.data;
+
+    if (data) {
+      return data;
+    }
+
     return {
       evidenceFiles: [],
       renderEvidenceFields: false

--- a/components/badges/RequirementsList.jsx
+++ b/components/badges/RequirementsList.jsx
@@ -5,13 +5,14 @@ var RequirementsList = React.createClass({
   propTypes: {
     criteria    : React.PropTypes.array.isRequired,
     evidence    : React.PropTypes.array,
+    data        : React.PropTypes.array,
     className   : React.PropTypes.string,
     icon        : React.PropTypes.string
   },
 
   getInitialState() {
     return {
-      evidenceReceived: []
+      evidenceReceived: this.props.data || []
     };
   },
 
@@ -35,13 +36,15 @@ var RequirementsList = React.createClass({
     var listItems = criteria.map((item, position) => {
       if (item) {
         let ev = (evidence ? evidence[position] : false);
+        let data = this.state.evidenceReceived[position];
 
         return <RequirementRow
                   position={position}
                   key={position + '-' + item}
-                  icon={this.state.evidenceReceived[position] ? icon : false}
+                  icon={data ? icon : false}
                   description={item}
                   evidence={ev}
+                  data={data}
                   onEvidence={this.handleEvidence}
                />;
       }

--- a/pages/badges/badge-single.jsx
+++ b/pages/badges/badge-single.jsx
@@ -403,6 +403,7 @@ var BadgePage = React.createClass({
           icon="fa fa-check"
           criteria={applicationCriteriaList}
           evidence={requiredEvidenceList}
+          data={this.state.evidence}
           onEvidence={this.setEvidence}
         />
       </div>


### PR DESCRIPTION
How to test this: in `badge-single.jsx`, have the `claimBadge` function start as:

```
  claimBadge: function() {
    var evidences = [];
    var userSupplied = this.state.evidence;

    return this.setState({
      applying: true,
      showApplyModal: true,
      canCloseModal: false
    }, function() {
      this.handleClaimRequest(true, { error: false });
    });

    ...rest of code...
```

This bypasses the actual badge application and triggers the callback for a failed application - any evidence you may have filled in should be preserved now, rather than getting completely wiped empty.