### PR TITLE
Temporarily link to etherpad externally

### DIFF
--- a/pages/community-call.jsx
+++ b/pages/community-call.jsx
@@ -44,13 +44,13 @@ var CommunityCallPage = React.createClass({
           <iframe width="560" height="315" src="https://air.mozilla.org/mozilla-learning-community-call-youth-leadership-2016-11-16/video/" frameBorder="0" allowFullScreen></iframe>
           </div>
 
-          <h4>
-            Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/mozcommunitycallnov16">
-            </a>
-          </h4>
+          <h3>Open Agenda</h3>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/mozcommunitycallnov16"></iframe>
+          <p>
+            <a title="Open the agenda in a new tab" href="https://public.etherpad-mozilla.org/p/mozcommunitycallnov16" target="_blank">
+            Click here to view the agenda
+            </a>
+          </p>
 
           <h2>Upcoming Calls</h2>
 

--- a/pages/curriculum-workshop.jsx
+++ b/pages/curriculum-workshop.jsx
@@ -48,13 +48,13 @@ var CurriculumWorkshop = React.createClass({
           <iframe width="560" height="315" src="https://air.mozilla.org/mozilla-curriculum-workshop-youth-leadership/video/" frameBorder="0" allowFullScreen></iframe>
           </div>
 
-          <h4>
-            Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-november-17-2016">
-            </a>
-          </h4>
+          <h3>Open Agenda</h3>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-november-17-2016"></iframe>
+          <p>
+            <a title="Open the agenda in a new tab" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-november-17-2016" target="_blank">
+            Click here to view the agenda
+            </a>
+          </p>
 
           <h2>Upcoming Workshops</h2>
 


### PR DESCRIPTION
Looks like etherpad has buffed their security and we can no longer put it in an iframe on our site.

Since our community call is today evening, for now I just made it clearer that they need to click on a link to open the etherpad in a new tab.