### PR TITLE
use double quotes instead of single quotes

### DIFF
--- a/config/webpack/webpack.client.config.js
+++ b/config/webpack/webpack.client.config.js
@@ -66,7 +66,7 @@ var webpackConfig = {
       // feature flags:
       "ENABLE_BADGES",
       "ENABLE_PONTOON",
-      'HIDE_NEWSLETTER_SIGNUP_FORM',
+      "HIDE_NEWSLETTER_SIGNUP_FORM",
 
       "LOGIN_EMULATION",
       "LOGIN_EMULATION_LOGGEDOUT",


### PR DESCRIPTION
just to keep things consistent