### PR TITLE
updates to MCW page

### DIFF
--- a/lib/routes.jsx
+++ b/lib/routes.jsx
@@ -55,6 +55,7 @@ var pages = {
   'community/curriculum-workshop/sept-29-2016': require('../pages/curriculum-workshop-sept-29-2016.jsx'),
   'community/curriculum-workshop/oct-11-2016': require('../pages/curriculum-workshop-oct-11-2016.jsx'),
   'community/curriculum-workshop/oct-30-2016': require('../pages/curriculum-workshop-oct-30-2016.jsx'),
+  'community/curriculum-workshop/feb-16-2017': require('../pages/curriculum-workshop-feb-16-2017.jsx'),
   'community/community-call': require('../pages/community-call.jsx'),
   'community/community-call/march-23-2016': require('../pages/community-call-march-23.jsx'),
   'community/community-call/april-20-2016': require('../pages/community-call-april-20.jsx'),

--- a/pages/curriculum-workshop-feb-16-2017.jsx
+++ b/pages/curriculum-workshop-feb-16-2017.jsx
@@ -28,7 +28,7 @@ var CurriculumWorkshop = React.createClass({
 
           <section className="callout-box past-workshop">
             <h2>Past Workshop</h2>
-            <p className="date">February 16th - 7am PT/ 10am ET/ 2pm UTC</p>
+            <p className="date">February 16th - 7am PT, 10am ET, 2pm UTC</p>
             <h1>Privacy & Security</h1>
           </section>
 

--- a/pages/curriculum-workshop-feb-16-2017.jsx
+++ b/pages/curriculum-workshop-feb-16-2017.jsx
@@ -1,0 +1,62 @@
+var React = require('react');
+var HeroUnit = require('../components/hero-unit.jsx');
+// use this LinkAnchorSwap component for hyperlinks
+var LinkAnchorSwap = require('../components/link-anchor-swap.jsx');
+var Illustration = require('../components/illustration.jsx');
+
+var CurriculumWorkshop = React.createClass({
+  statics: {
+    pageClassName: 'curriculum-workshop',
+    pageTitle: 'Curriculum Workshops'
+  },
+  render: function () {
+    return (
+        <div className="inner-container call-container">
+          <section className="intro intro-after-banner">
+           <Illustration
+             height={175} width={175}
+             src1x="/img/pages/community/svg/icon-circle-community.svg"
+             alt="icon toolkit">
+               <h1>Mozilla Curriculum Workshop</h1>
+               <h2>Join us on the second Tuesday of each month!</h2>
+           </Illustration>
+          </section>
+
+          <p>
+            Co-hosts Amira Dhalla and Chad Sansing, along with producers Kristina Gorr and Paul Oh, help participants answer the question, <em>"How can I use the web to teach and learn what’s important to me?"</em> Join us as we prototype teaching and learning materials live on-air and think out-loud through the curriculum design process.
+          </p>
+
+          <section className="callout-box past-workshop">
+            <h2>Past Workshop</h2>
+            <p className="date">February 16th - 7am PT/ 10am ET/ 2pm UTC</p>
+            <h1>Privacy & Security</h1>
+          </section>
+
+          <p>
+           Join us for a discussion about the privacy and security as we begin a new quarterly schedule on the Mozilla Curriculum Workshop. What are the privacy and security choices that face youth every day? How can we help them develop the habits they need to keep themselves safe as participants on an open and free internet? How might we contribute to internet health by promoting strong privacy rights for all? Join co-hosts Amira Dhalla and Chad Sansing as they talk and prototype learning materials with Vishal Chavan, Cynthia Lieberman, and Chad Walker.
+          </p>
+
+          <p>
+            You can also join the discussion on <LinkAnchorSwap to="https://discourse.webmaker.org/c/mozilla-curriculum-workshop">our community forum</LinkAnchorSwap> or <LinkAnchorSwap to="https://github.com/MozillaFoundation/curriculum-workshop">GitHub</LinkAnchorSwap>.
+          </p>
+
+          <h3>Workshop Video Stream</h3>
+
+          <div className="video-wrapper">
+            <iframe className="workshop-video" width="560" height="315" src="https://air.mozilla.org/mozilla-curriculum-workshop-february-2017-privacy-security/video" frameBorder="0" allowFullScreen></iframe>
+          </div>
+
+          <h4>
+            Open Agenda
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-february-16-2017">
+            </a>
+          </h4>
+
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-february-16-2017"></iframe>
+
+        </div>
+    );
+  }
+});
+
+module.exports = CurriculumWorkshop;

--- a/pages/curriculum-workshop.jsx
+++ b/pages/curriculum-workshop.jsx
@@ -28,12 +28,12 @@ var CurriculumWorkshop = React.createClass({
 
           <section className="callout-box">
             <h2>Upcoming Workshop</h2>
-            <p className="date">February 16, 7 AM PT / 10 AM ET / 2PM UTC</p>
-            <h1>Privacy & Security</h1>
+            <p className="date">May 11, 2017 7 AM PT / 10 AM ET / 2PM UTC</p>
+            <h1>Fake News & Misinformation</h1>
           </section>
 
           <p>
-            Join us for a discussion about the privacy and security as we begin a new quarterly schedule on the Mozilla Curriculum Workshop. What are the privacy and security choices that face youth every day? How can we help them develop the habits they need to keep themselves safe as participants on an open and free internet? How might we contribute to internet health by promoting strong privacy rights for all? Join co-hosts Amira Dhalla and Chad Sansing as they talk and prototype learning materials with Vishal Chavan, Cynthia Lieberman, and Chad Walker.
+            Join us for a discussion of fake news, misinformation, and how to help students navigate and create today’s media landscape. Guests Janelle Bence, Sarah Morris, and Hannah Kane will help us imagine and prototype resources to teach media literacy on the web.
           </p>
 
           <p>
@@ -45,27 +45,20 @@ var CurriculumWorkshop = React.createClass({
             On the day of the Curriculum Workshop, the livestream will appear below. You may need to refresh your browser.
           </p>
           <div className="video-wrapper">
-          <iframe width="560" height="315" src="https://air.mozilla.org/mozilla-curriculum-workshop-february-2017-privacy-security/video" frameBorder="0" allowFullScreen></iframe>
+          <iframe width="560" height="315" src="https://air.mozilla.org/mozilla-curriculum-workshop-spring-2017/video" frameBorder="0" allowFullScreen></iframe>
           </div>
 
           <h4>
             Open Agenda
-            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-february-16-2017">
+            <a title="Open the agenda in a new tab" className="fa fa-external-link open-etherpad" href="https://public.etherpad-mozilla.org/p/curriculum-workshop-may-11-2017">
             </a>
           </h4>
 
-          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-february-16-2017"></iframe>
+          <iframe className="etherpad" src="https://public.etherpad-mozilla.org/p/curriculum-workshop-may-11-2017"></iframe>
 
           <h2>Upcoming Workshops</h2>
 
           <ul className="upcoming-workshops">
-            <li>
-              <p className="date">May 11th, 2017, 10am ET</p>
-              <h2>Fake News</h2>
-              <p>
-                Join us on Thursday, May 11th, 2017, at 10 AM ET, to talk about teaching and learning in response to the Fake News phenomenon.
-              </p>
-            </li>
             <li>
               <p className="date">August 10th, 2017, 10am ET</p>
               <h2>Online Safety</h2>
@@ -85,6 +78,16 @@ var CurriculumWorkshop = React.createClass({
           <h2>Past Workshops</h2>
 
           <ul className="past-workshops">
+            <li>
+              <p className="date">February 16th, 2017</p>
+              <h2>Privacy & Security</h2>
+              <p>
+                Join us for a discussion about the privacy and security as we begin a new quarterly schedule on the Mozilla Curriculum Workshop. What are the privacy and security choices that face youth every day? How can we help them develop the habits they need to keep themselves safe as participants on an open and free internet? How might we contribute to internet health by promoting strong privacy rights for all? Join co-hosts Amira Dhalla and Chad Sansing as they talk and prototype learning materials with Vishal Chavan, Cynthia Lieberman, and Chad Walker.
+              </p>
+              <p className="watch-archive">
+                <LinkAnchorSwap to="/community/curriculum-workshop/feb-16-2017/">Watch the Replay</LinkAnchorSwap>
+              </p>
+            </li>
             <li>
               <p className="date">October 30th, 2016</p>
               <h2>Live from MozFest</h2>


### PR DESCRIPTION
Fixes #2478

**Changes proposed in this pull request:**
- updates Curriculum Workshop landing page with upcoming call info
- adds route to a new page, which archives the most recently passed call


